### PR TITLE
add support for retro devices

### DIFF
--- a/app/ytdl.py
+++ b/app/ytdl.py
@@ -36,8 +36,9 @@ class Download:
         self.download_dir = download_dir
         if quality == 'best':
             self.format = None
-        elif quality == 'retro':
-            self.format = f'bestvideo[ext=mp4]+bestaudio[ext=aac]/best[ext=mp4]/best'
+        elif 'custom' in quality:
+            quality = quality.replace('custom:', '')
+            self.format = f'{quality}'
         elif quality in ('1080p', '720p', '480p'):
             res = quality[:-1]
             self.format = f'bestvideo[height<={res}]+bestaudio/best[height<={res}]'

--- a/app/ytdl.py
+++ b/app/ytdl.py
@@ -36,6 +36,8 @@ class Download:
         self.download_dir = download_dir
         if quality == 'best':
             self.format = None
+        elif quality == 'retro':
+            self.format = f'bestvideo[ext=mp4]+bestaudio[ext=aac]/best[ext=mp4]/best'
         elif quality in ('1080p', '720p', '480p'):
             res = quality[:-1]
             self.format = f'bestvideo[height<={res}]+bestaudio/best[height<={res}]'


### PR DESCRIPTION
Would you consider adding a new quality type, that would allow this service to request "safe" content for retro devices? I've been testing this for the past 3 weeks on a range of devices made between 2008 and 2011 and it works flawlessly with the quality settings I've included as "retro" in this pull request.
I didn't modify the UI since a) I suck at Angular and b) retro devices need their own UI anyway.