### PR TITLE
Multi platform build

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ A Docker image can be built locally (it will build the UI too):
 docker build -t metube .
 ```
 
+A Multi-Platform Docker image can be built locally:
+
+```bash
+build-multi-platform.sh
+```
+
 ## Development notes
 
 * The above works on Windows as well as Linux.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,17 @@ docker build -t metube .
 A Multi-Platform Docker image can be built locally:
 
 ```bash
+# Build with tag "metube"
 build-multi-platform.sh
+
+# Build with tag "other_tag"
+build-multi-platform.sh -t "other_tag"
+
+# Build with tag "metube" and Upload do Docker Registry
+build-multi-platform.sh -p true
+
+# Build with tag "other_tag" and Upload do Docker Registry
+build-multi-platform.sh -t "other_tag" -p true
 ```
 
 ## Development notes

--- a/build-multi-platform.sh
+++ b/build-multi-platform.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+TAG="metube"
+PUSH="false"
+
+# Proccess Arguments
+
+while getopts ":hhelpf:t:p:" ARGS;
+do
+    case $ARGS in
+        h|help )
+            echo -e "Usgae:\n\t-t \"Tag\"\n\t\tuse a specific Tag\n\t-p true\n\t\tPush the Image do a registry. Needs to be logged in (docker login).\n\t-h\n\t\t Show this Help Dialog"
+            exit 1
+            ;;
+        t )
+            TAG="${OPTARG}"
+            ;;
+        p )
+            PUSH="${OPTARG}"
+            ;;
+    esac
+done
+
+# Fail on Error
+set -e
+
+# Register Arm executables to run on x64 machines
+docker run --rm --privileged docker/binfmt:820fdd95a9972a5308930a2bdfb8573dd4447ad3
+
+# Test if qemu is enabeld
+cat /proc/sys/fs/binfmt_misc/qemu-aarch64 | head -n 1 | grep -q "enabled"
+
+# Create a Builder if needed
+if docker buildx ls | grep -q "multiArchBuilder"; then
+    echo "Builder \"multiArchBuilder\" aready exists."
+else
+    echo "Builder \"multiArchBuilder\" will be created."
+
+    docker buildx create --name "multiArchBuilder"
+fi
+
+# Switch to Builder "multiArchBuilder"
+docker buildx use "multiArchBuilder"
+
+# Test if current Builder Contains needed Architectures
+BOOTSTRAP=$(docker buildx inspect --bootstrap)
+
+echo $BOOTSTRAP | grep -q "linux/amd64"
+echo $BOOTSTRAP | grep -q "linux/arm64"
+echo $BOOTSTRAP | grep -q "linux/arm/v7"
+
+# Build Image
+echo "Use Tag \"$TAG\" for Build"
+if [ "$PUSH" = "true" ]; then
+    # Build with Push
+    docker buildx build --platform linux/arm,linux/arm64,linux/amd64 -t "$TAG" --push .
+else
+    # Build without Push
+    docker buildx build --platform linux/arm,linux/arm64,linux/amd64 -t "$TAG" .
+fi


### PR DESCRIPTION
I have added a script for building multi-platform images.
This could also be embedded in a CI platform.

It would be cool if you could run the build with "-p true" so I don't have to upload the image to Docker Hub myself ...
If you want, I'd be happy to help you create a CI pipeline for this project.  Just get in touch with me.

Many greetings
Florian

Fixes #12