### PR TITLE
Added local dev environment via separated docker containers

### DIFF
--- a/Dockerfile-dev-backend
+++ b/Dockerfile-dev-backend
@@ -1,0 +1,18 @@
+FROM python:3.8-alpine
+
+COPY . /app
+
+WORKDIR /app
+
+RUN apk add --update ffmpeg && \
+    apk add --update --virtual .build-deps gcc musl-dev && \
+    pip install --no-cache-dir pipenv && \
+    pipenv install --system --deploy --clear && \
+    pip uninstall pipenv -y && \
+    apk del .build-deps && \
+    rm -rf /var/cache/apk/*
+
+ENV DOWNLOAD_DIR /downloads
+VOLUME /downloads
+EXPOSE 8081
+CMD ["python3", "app/main.py"]

--- a/Dockerfile-dev-frontend
+++ b/Dockerfile-dev-frontend
@@ -1,0 +1,10 @@
+FROM node:16-alpine
+
+COPY ./ui /app
+
+WORKDIR /app
+
+RUN npm ci && \
+    node_modules/.bin/ng build
+
+CMD ["node_modules/.bin/ng", "build", "--watch"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: serve-dev build build-dev attach-dev-frontend attach-dev-backend
+
+serve-dev:
+	docker-compose up
+
+attach-dev-frontend:
+	docker exec -it -t metube-dev-frontend /bin/sh
+
+attach-dev-backend:
+	docker exec -it -t metube-dev-backend /bin/sh
+
+build-dev:
+	docker-compose build
+
+build:
+	docker build -t metube .

--- a/README.md
+++ b/README.md
@@ -75,6 +75,23 @@ If you're using the [linuxserver/swag](https://docs.linuxserver.io/general/swag)
 
 ## Build and run locally
 
+A Docker image can be built locally (it will build the UI too):
+
+```bash
+make build
+```
+
+### Run dev mode with local docker
+
+```bash
+make serve-dev
+```
+It will launch two containers: `metube-dev-frontend` and `metube-dev-backend`. Frontend will be started in watching mode but backend need to be restarted after code changes - `docker restart metube-dev-backend`
+
+After first start `metube-dev-backend` may crashed with error about nonexistent files - it's normal, just wait while frontend will be build and restart backend.
+
+### Run without docker
+
 Make sure you have node.js and Python 3.8 installed.
 
 ```bash
@@ -90,11 +107,6 @@ pipenv install
 pipenv run python3 app/main.py
 ```
 
-A Docker image can be built locally (it will build the UI too):
-
-```bash
-docker build -t metube .
-```
 
 ## Development notes
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+version: "3"
+
+services:
+    backend:
+        build:
+            context: .
+            dockerfile: Dockerfile-dev-backend
+        container_name: metube-dev-backend
+        image: metube-dev-backend
+        expose:
+            - 8081
+        ports:
+            - "8081:8081"
+        links:
+            - frontend
+        volumes:
+            - ./ui:/app/ui
+            - ./app:/app/app
+
+    frontend:
+        build:
+            context: .
+            dockerfile: Dockerfile-dev-frontend
+        container_name: metube-dev-frontend
+        image: metube-dev-frontend
+        expose:
+            - 4200
+        volumes:
+            - ./ui:/app


### PR DESCRIPTION
While i worked on another PR i need to run application in development mode but i didn't want install requirements in OS.

I create two separate docker files for dev containers, wrote docker compose file and pack commands into makefile.