### PR TITLE
Add download link to downloaded file

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -108,6 +108,7 @@ if config.URL_PREFIX != '/':
         return web.HTTPFound(config.URL_PREFIX)
 
 routes.static(config.URL_PREFIX + 'favicon/', 'favicon')
+routes.static(config.URL_PREFIX + 'download/', config.DOWNLOAD_DIR)
 routes.static(config.URL_PREFIX, 'ui/dist/metube')
 app.add_routes(routes)
 

--- a/ui/src/app/app.component.html
+++ b/ui/src/app/app.component.html
@@ -112,7 +112,8 @@
             <fa-icon *ngIf="download.value.status == 'finished'" [icon]="faCheckCircle" style="color: green;"></fa-icon>
             <fa-icon *ngIf="download.value.status == 'error'" [icon]="faTimesCircle" style="color: red;"></fa-icon>
           </div>
-          <span ngbTooltip="{{download.value.msg}}">{{ download.value.title }}</span>
+          <span ngbTooltip="{{download.value.msg}}"><a *ngIf="!!download.value.filename; else noDownloadLink" href="download/{{download.value.filename}}" target="_blank">{{ download.value.title }}</a></span>
+          <ng-template #noDownloadLink>{{ download.value.title }}</ng-template>
         </td>
         <td>
           <button *ngIf="download.value.status == 'error'" type="button" class="btn btn-link" (click)="retryDownload(download.key, download.value.quality)"><fa-icon [icon]="faRedoAlt"></fa-icon></button>

--- a/ui/src/app/downloads.service.ts
+++ b/ui/src/app/downloads.service.ts
@@ -15,6 +15,7 @@ interface Download {
   url: string,
   status: string;
   msg: string;
+  filename: string;
   quality: string;
   percent: number;
   speed: number;


### PR DESCRIPTION
This adds a simple download link that points to the downloaded file.

Note: This makes all files in the download directory (and its
sub-directory) available to any user.


Closes #26 