### PR TITLE
Add m4a support and explicit audio format

### DIFF
--- a/app/dl_formats.py
+++ b/app/dl_formats.py
@@ -23,14 +23,13 @@ def get_format(format: str, quality: str) -> str:
         # Quality is irrelevant in this case since we skip the download
         return "bestaudio/best"
 
-    if format == "mp3":
+    if format in ("m4a", "mp3"):
         # Audio quality needs to be set post-download, set in opts
         return "bestaudio/best"
 
     if format in ("mp4", "any"):
         if quality == "audio":
             return "bestaudio/best"
-
         # video {res} {vfmt} + audio {afmt} {res} {vfmt}
         vfmt, afmt = ("[ext=mp4]", "[ext=m4a]") if format == "mp4" else ("", "")
         vres = f"[height<={quality}]" if quality != "best" else ""
@@ -60,12 +59,13 @@ def get_opts(format: str, quality: str, ytdl_opts: dict) -> dict:
     if "postprocessors" not in opts:
         opts["postprocessors"] = []
 
-    if format == "mp3":
+    if format in ("m4a", "mp3"):
         opts["postprocessors"].append({
             "key": "FFmpegExtractAudio",
-            "preferredcodec": "mp3",
+            "preferredcodec": format,
             "preferredquality": 0 if quality == "best" else quality,
         })
+
         opts["writethumbnail"] = True
         opts["postprocessors"].append({"key": "FFmpegThumbnailsConvertor", "format": "jpg", "when": "before_dl"})
         opts["postprocessors"].append({"key": "FFmpegMetadata"})

--- a/app/ytdl.py
+++ b/app/ytdl.py
@@ -234,7 +234,7 @@ class DownloadQueue:
             if not self.queue.exists(entry['id']):
                 dl = DownloadInfo(entry['id'], entry['title'], entry.get('webpage_url') or entry['url'], quality, format, folder)
                 # Keep consistent with frontend
-                base_directory = self.config.DOWNLOAD_DIR if (quality != 'audio' and format != 'mp3') else self.config.AUDIO_DOWNLOAD_DIR
+                base_directory = self.config.DOWNLOAD_DIR if (quality != 'audio' and format  not in ("m4a", "mp3")) else self.config.AUDIO_DOWNLOAD_DIR
                 if folder:
                     if not self.config.CUSTOM_DIRS:
                         return {'status': 'error', 'msg': f'A folder for the download was specified but CUSTOM_DIRS is not true in the configuration.'}

--- a/ui/src/app/app.component.ts
+++ b/ui/src/app/app.component.ts
@@ -94,7 +94,7 @@ export class AppComponent implements AfterViewInit {
   }
 
   isAudioType() {
-    return this.quality == 'audio' || this.format == 'mp3';
+    return this.quality == 'audio' || this.format == 'mp3'  || this.format == 'm4a';
   }
 
   getMatchingCustomDir() : Observable<string[]> {

--- a/ui/src/app/formats.ts
+++ b/ui/src/app/formats.ts
@@ -23,6 +23,15 @@ export const Formats: Format[] = [
     ],
   },
   {
+    id: 'm4a',
+    text: 'M4A',
+    qualities: [
+      { id: 'best', text: 'Best' },
+      { id: '192', text: '192 kbps' },
+      { id: '128', text: '128 kbps' },
+    ],
+  },
+  {
     id: 'mp4',
     text: 'MP4',
     qualities: [


### PR DESCRIPTION
This PR add m4a audio format support that is native to many ytb videos and could avoid transcoding. 
Also replaces the "Any" format, with explicit format selector which will also drive the quality selector.  


![image](https://user-images.githubusercontent.com/11028401/219898640-a513f5e3-17e6-4685-aece-45c7d2fd9a3c.png)
![image](https://user-images.githubusercontent.com/11028401/219898647-4d7daeae-7b81-4d98-82c5-589b537e6419.png)
![image](https://user-images.githubusercontent.com/11028401/219898720-707c66a0-20cb-4972-bf50-07382607f380.png)
