### PR TITLE
Create build-ghcr-docker-image.yml

### DIFF
--- a/.github/workflows/build-ghcr-docker-image.yml
+++ b/.github/workflows/build-ghcr-docker-image.yml
@@ -1,0 +1,27 @@
+name: Build Docker Image
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Login to Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }} 
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          context: . 
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+            ghcr.io/${{ github.repository }}:latest


### PR DESCRIPTION
This builds a docker image and pushes it to the GitHub container registry using the default (repo owner) tokens - but only when a new git tag is pushed.