### PR TITLE
Fix error because of missing cache directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ RUN chmod +x docker-entrypoint.sh && \
     pipenv install --system --deploy --clear && \
     pip uninstall pipenv -y && \
     apk del .build-deps && \
-    rm -rf /var/cache/apk/*
+    rm -rf /var/cache/apk/* && \
+    mkdir /.cache && chmod 777 /.cache
 
 COPY favicon ./favicon
 COPY app ./app

--- a/app/ytdl.py
+++ b/app/ytdl.py
@@ -78,7 +78,6 @@ class Download:
                 'paths': {"home": self.download_dir},
                 'outtmpl': { "default": self.output_template, "chapter": self.output_template_chapter },
                 'format': self.format,
-                'cachedir': False,
                 'socket_timeout': 30,
                 'progress_hooks': [put_status],
                 'postprocessor_hooks': [put_status_postprocessor],


### PR DESCRIPTION
Previously when downloading age restricted video from YouTube you got the error "PermissionError: [Errno 13] Permission denied: '/.cache'" from yt-dlp. This pull request fixes it by creating the necessary directory with the correct permissions in the container.