### PR TITLE
Introduce environment options DELETE_FILE_ON_TRASHCAN and DOWNLOAD_DIRS_INDEXABLE

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Certain values can be set via environment variables, using the `-e` parameter on
 * __CUSTOM_DIRS__: whether to enable downloading videos into custom directories within the __DOWNLOAD_DIR__ (or __AUDIO_DOWNLOAD_DIR__). When enabled, a drop-down appears next to the Add button to specify the download directory. Defaults to `true`.
 * __CREATE_CUSTOM_DIRS__: whether to support automatically creating directories within the __DOWNLOAD_DIR__ (or __AUDIO_DOWNLOAD_DIR__) if they do not exist. When enabled, the download directory selector becomes supports free-text input, and the specified directory will be created recursively. Defaults to `true`.
 * __STATE_DIR__: path to where the queue persistence files will be saved. Defaults to `/downloads/.metube` in the docker image, and `.` otherwise.
+* __DELETE_FILE_ON_TRASHCAN__: if `true`, downloaded files are deleted on the server, when they are trashed from the "Completed" section of the UI. Defaults to `false`.
 * __URL_PREFIX__: base path for the web server (for use when hosting behind a reverse proxy). Defaults to `/`.
 * __OUTPUT_TEMPLATE__: the template for the filenames of the downloaded videos, formatted according to [this spec](https://github.com/yt-dlp/yt-dlp/blob/master/README.md#output-template). Defaults to `%(title)s.%(ext)s`.
 * __OUTPUT_TEMPLATE_CHAPTER__: the template for the filenames of the downloaded videos, when split into chapters via postprocessors. Defaults to `%(title)s - %(section_number)s %(section_title)s.%(ext)s`.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Certain values can be set via environment variables, using the `-e` parameter on
 * __UMASK__: umask value used by MeTube. Defaults to `022`.
 * __DOWNLOAD_DIR__: path to where the downloads will be saved. Defaults to `/downloads` in the docker image, and `.` otherwise.
 * __AUDIO_DOWNLOAD_DIR__: path to where audio-only downloads will be saved, if you wish to separate them from the video downloads. Defaults to the value of `DOWNLOAD_DIR`.
+* __DOWNLOAD_DIRS_INDEXABLE__: if `true`, the download dirs (__DOWNLOAD_DIR__ and __AUDIO_DOWNLOAD_DIR__) are indexable on the webserver. Defaults to `false`.
 * __CUSTOM_DIRS__: whether to enable downloading videos into custom directories within the __DOWNLOAD_DIR__ (or __AUDIO_DOWNLOAD_DIR__). When enabled, a drop-down appears next to the Add button to specify the download directory. Defaults to `true`.
 * __CREATE_CUSTOM_DIRS__: whether to support automatically creating directories within the __DOWNLOAD_DIR__ (or __AUDIO_DOWNLOAD_DIR__) if they do not exist. When enabled, the download directory selector becomes supports free-text input, and the specified directory will be created recursively. Defaults to `true`.
 * __STATE_DIR__: path to where the queue persistence files will be saved. Defaults to `/downloads/.metube` in the docker image, and `.` otherwise.

--- a/app/main.py
+++ b/app/main.py
@@ -17,6 +17,7 @@ class Config:
     _DEFAULTS = {
         'DOWNLOAD_DIR': '.',
         'AUDIO_DOWNLOAD_DIR': '%%DOWNLOAD_DIR',
+        'DOWNLOAD_DIRS_INDEXABLE': 'false',
         'CUSTOM_DIRS': 'true',
         'CREATE_CUSTOM_DIRS': 'true',
         'DELETE_FILE_ON_TRASHCAN': 'false',
@@ -30,7 +31,7 @@ class Config:
         'BASE_DIR': ''
     }
 
-    _BOOLEAN = ('CUSTOM_DIRS', 'CREATE_CUSTOM_DIRS', 'DELETE_FILE_ON_TRASHCAN')
+    _BOOLEAN = ('DOWNLOAD_DIRS_INDEXABLE', 'CUSTOM_DIRS', 'CREATE_CUSTOM_DIRS', 'DELETE_FILE_ON_TRASHCAN')
 
     def __init__(self):
         for k, v in self._DEFAULTS.items():
@@ -163,8 +164,8 @@ if config.URL_PREFIX != '/':
         return web.HTTPFound(config.URL_PREFIX)
 
 routes.static(config.URL_PREFIX + 'favicon/', os.path.join(config.BASE_DIR, 'favicon'))
-routes.static(config.URL_PREFIX + 'download/', config.DOWNLOAD_DIR)
-routes.static(config.URL_PREFIX + 'audio_download/', config.AUDIO_DOWNLOAD_DIR)
+routes.static(config.URL_PREFIX + 'download/', config.DOWNLOAD_DIR, show_index=config.DOWNLOAD_DIRS_INDEXABLE)
+routes.static(config.URL_PREFIX + 'audio_download/', config.AUDIO_DOWNLOAD_DIR, show_index=config.DOWNLOAD_DIRS_INDEXABLE)
 routes.static(config.URL_PREFIX, os.path.join(config.BASE_DIR, 'ui/dist/metube'))
 try:
     app.add_routes(routes)

--- a/app/main.py
+++ b/app/main.py
@@ -19,6 +19,7 @@ class Config:
         'AUDIO_DOWNLOAD_DIR': '%%DOWNLOAD_DIR',
         'CUSTOM_DIRS': 'true',
         'CREATE_CUSTOM_DIRS': 'true',
+        'DELETE_FILE_ON_TRASHCAN': 'false',
         'STATE_DIR': '.',
         'URL_PREFIX': '',
         'OUTPUT_TEMPLATE': '%(title)s.%(ext)s',
@@ -29,7 +30,7 @@ class Config:
         'BASE_DIR': ''
     }
 
-    _BOOLEAN = ('CUSTOM_DIRS', 'CREATE_CUSTOM_DIRS')
+    _BOOLEAN = ('CUSTOM_DIRS', 'CREATE_CUSTOM_DIRS', 'DELETE_FILE_ON_TRASHCAN')
 
     def __init__(self):
         for k, v in self._DEFAULTS.items():

--- a/app/ytdl.py
+++ b/app/ytdl.py
@@ -292,6 +292,9 @@ class DownloadQueue:
             if not self.done.exists(id):
                 log.warn(f'requested delete for non-existent download {id}')
                 continue
+            if self.config.DELETE_FILE_ON_TRASHCAN:
+                dl = self.done.get(id)
+                os.remove(os.path.join(dl.download_dir, dl.info.filename))
             self.done.delete(id)
             await self.notifier.cleared(id)
         return {'status': 'ok'}


### PR DESCRIPTION
Hi @alexta69,

thanks for the awesome work here.

I introduced two new environment options:
* DELETE_FILE_ON_TRASHCAN to fix #108 
* DOWNLOAD_DIRS_INDEXABLE to make the downloads dir indexable (which I would like)

If any of this does not suite your standards or you want to have the things in separate PRs, just let me know.

Thanks and have a nice sunday!