### PR TITLE
Add default theme option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Certain values can be set via environment variables, using the `-e` parameter on
 * __UID__: user under which MeTube will run. Defaults to `1000`.
 * __GID__: group under which MeTube will run. Defaults to `1000`.
 * __UMASK__: umask value used by MeTube. Defaults to `022`.
+* __DARK_MODE__: if set to `true`, the UI will be in dark mode. Defaults to `false`.
 * __DOWNLOAD_DIR__: path to where the downloads will be saved. Defaults to `/downloads` in the docker image, and `.` otherwise.
 * __AUDIO_DOWNLOAD_DIR__: path to where audio-only downloads will be saved, if you wish to separate them from the video downloads. Defaults to the value of `DOWNLOAD_DIR`.
 * __DOWNLOAD_DIRS_INDEXABLE__: if `true`, the download dirs (__DOWNLOAD_DIR__ and __AUDIO_DOWNLOAD_DIR__) are indexable on the webserver. Defaults to `false`.

--- a/app/main.py
+++ b/app/main.py
@@ -29,10 +29,11 @@ class Config:
         'YTDL_OPTIONS': '{}',
         'HOST': '0.0.0.0',
         'PORT': '8081',
-        'BASE_DIR': ''
+        'BASE_DIR': '',
+        'DARK_MODE': 'false'
     }
 
-    _BOOLEAN = ('DOWNLOAD_DIRS_INDEXABLE', 'CUSTOM_DIRS', 'CREATE_CUSTOM_DIRS', 'DELETE_FILE_ON_TRASHCAN')
+    _BOOLEAN = ('DOWNLOAD_DIRS_INDEXABLE', 'CUSTOM_DIRS', 'CREATE_CUSTOM_DIRS', 'DELETE_FILE_ON_TRASHCAN', 'DARK_MODE')
 
     def __init__(self):
         for k, v in self._DEFAULTS.items():
@@ -153,7 +154,9 @@ def get_custom_dirs():
 
 @routes.get(config.URL_PREFIX)
 def index(request):
-    return web.FileResponse(os.path.join(config.BASE_DIR, 'ui/dist/metube/index.html'))
+    response = web.FileResponse(os.path.join(config.BASE_DIR, 'ui/dist/metube/index.html'))
+    response.set_cookie('metube_dark', 'true' if config.DARK_MODE else 'false')
+    return response
 
 if config.URL_PREFIX != '/':
     @routes.get('/')


### PR DESCRIPTION
Dark mode can be set to the default theme by setting 'DARK_MODE' environment variable to `true`
#171 