### PR TITLE
Fix issues with deleting files with DELETE_FILE_ON_TRASHCAN

### DIFF
--- a/app/ytdl.py
+++ b/app/ytdl.py
@@ -300,7 +300,10 @@ class DownloadQueue:
                 continue
             if self.config.DELETE_FILE_ON_TRASHCAN:
                 dl = self.done.get(id)
-                os.remove(os.path.join(dl.download_dir, dl.info.filename))
+                try:
+                    os.remove(os.path.join(dl.download_dir, dl.info.filename))
+                except Exception as e:
+                    log.warn(f'deleting file for download {id} failed with error message {e}')
             self.done.delete(id)
             await self.notifier.cleared(id)
         return {'status': 'ok'}


### PR DESCRIPTION
Not being able to delete the file should not stop the clearance from the download list.

One error I encountered, is when failed downloads have no dl.info.filename attribute. It was impossible to delete these entries from the "Completed" section.