### PR TITLE
undo #265

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ FROM python:3.8-alpine
 
 WORKDIR /app
 
-COPY Pipfile* docker-entrypoint.sh .
+COPY Pipfile* docker-entrypoint.sh ./
 
 # Use sed to strip carriage-return characters from the entrypoint script (in case building on Windows)
 # Install dependencies


### PR DESCRIPTION
```
Step 7/21 : COPY Pipfile* docker-entrypoint.sh .
When using COPY with more than one source file, the destination must be a directory and end with a /
```
why.....