### PR TITLE
Fix retry button issues

### DIFF
--- a/ui/src/app/app.component.html
+++ b/ui/src/app/app.component.html
@@ -140,7 +140,7 @@
           <ng-template #noDownloadLink>{{ download.value.title }}</ng-template>
         </td>
         <td>
-          <button *ngIf="download.value.status == 'error'" type="button" class="btn btn-link" (click)="retryDownload(download.key, download.value.url, download.value.quality, download.value.folder)"><fa-icon [icon]="faRedoAlt"></fa-icon></button>
+          <button *ngIf="download.value.status == 'error'" type="button" class="btn btn-link" (click)="retryDownload(download.key, download.value)"><fa-icon [icon]="faRedoAlt"></fa-icon></button>
         </td>
         <td>
           <a *ngIf="!!download.value.filename; else noDownloadLink" href="{{buildDownloadLink(download.value)}}" download><fa-icon [icon]="faDownload"></fa-icon></a>

--- a/ui/src/app/app.component.ts
+++ b/ui/src/app/app.component.ts
@@ -37,8 +37,8 @@ export class AppComponent implements AfterViewInit {
   faTimesCircle = faTimesCircle;
   faRedoAlt = faRedoAlt;
   faSun = faSun;
-  faMoon = faMoon;  
-  faDownload = faDownload;  
+  faMoon = faMoon;
+  faDownload = faDownload;
   faExternalLinkAlt = faExternalLinkAlt;
 
   constructor(public downloads: DownloadsService, private cookieService: CookieService) {
@@ -174,8 +174,8 @@ export class AppComponent implements AfterViewInit {
     });
   }
 
-  retryDownload(key: string, url: string, quality: string, format: string, folder: string, customNamePrefix: string) {
-    this.addDownload(url, quality, format, folder, customNamePrefix);
+  retryDownload(key: string, download: Download) {
+    this.addDownload(download.url, download.quality, download.format, download.folder, download.custom_name_prefix);
     this.downloads.delById('done', [key]).subscribe();
   }
 

--- a/ui/src/app/downloads.service.ts
+++ b/ui/src/app/downloads.service.ts
@@ -12,15 +12,17 @@ export interface Status {
 export interface Download {
   id: string;
   title: string;
-  url: string,
+  url: string;
+  quality: string;
+  format: string;
+  folder: string;
+  custom_name_prefix: string;
   status: string;
   msg: string;
-  filename: string;
-  folder: string;
-  quality: string;
   percent: number;
   speed: number;
   eta: number;
+  filename: string;
   checked?: boolean;
   deleting?: boolean;
 }


### PR DESCRIPTION
The arguments passed to `retryDownload` by the retry button do not match what the function actually expects. This causes a few issues:

- Downloads break if a custom folder is set
- Format and custom name prefix are not applied to the retried download

This PR fixes these problems by passing the entire download object to `retryDownload`, which now populates everything correctly. The `Download` interface was also updated to include all the fields actually sent by the server.

Fixes #233, #262 