### PR TITLE
Support loading YTDL_OPTIONS from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Certain values can be set via environment variables, using the `-e` parameter on
 * __URL_PREFIX__: base path for the web server (for use when hosting behind a reverse proxy). Defaults to `/`.
 * __OUTPUT_TEMPLATE__: the template for the filenames of the downloaded videos, formatted according to [this spec](https://github.com/yt-dlp/yt-dlp/blob/master/README.md#output-template). Defaults to `%(title)s.%(ext)s`.
 * __OUTPUT_TEMPLATE_CHAPTER__: the template for the filenames of the downloaded videos, when split into chapters via postprocessors. Defaults to `%(title)s - %(section_number)s %(section_title)s.%(ext)s`.
-* __YTDL_OPTIONS__: Additional options to pass to youtube-dl, This can be path to a file or or JSON format string. [See available options here](https://github.com/yt-dlp/yt-dlp/blob/master/yt_dlp/YoutubeDL.py#L183). They roughly correspond to command-line options, though some do not have exact equivalents here, for example `--recode-video` has to be specified via `postprocessors`. Also note that dashes are replaced with underscores.
+* __YTDL_OPTIONS__: Additional options to pass to youtube-dl, This can be path to a file or JSON formatted string. [See available options here](https://github.com/yt-dlp/yt-dlp/blob/master/yt_dlp/YoutubeDL.py#L183). They roughly correspond to command-line options, though some do not have exact equivalents here, for example `--recode-video` has to be specified via `postprocessors`. Also note that dashes are replaced with underscores.
 
 The following example value for `YTDL_OPTIONS` embeds English subtitles and chapter markers (for videos that have them), and also changes the permissions on the downloaded video and sets the file modification timestamp to the date of when it was downloaded:
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ Certain values can be set via environment variables, using the `-e` parameter on
 * __URL_PREFIX__: base path for the web server (for use when hosting behind a reverse proxy). Defaults to `/`.
 * __OUTPUT_TEMPLATE__: the template for the filenames of the downloaded videos, formatted according to [this spec](https://github.com/yt-dlp/yt-dlp/blob/master/README.md#output-template). Defaults to `%(title)s.%(ext)s`.
 * __OUTPUT_TEMPLATE_CHAPTER__: the template for the filenames of the downloaded videos, when split into chapters via postprocessors. Defaults to `%(title)s - %(section_number)s %(section_title)s.%(ext)s`.
-* __YTDL_OPTIONS__: Additional options to pass to youtube-dl, This can be path to a file or JSON formatted string. [See available options here](https://github.com/yt-dlp/yt-dlp/blob/master/yt_dlp/YoutubeDL.py#L183). They roughly correspond to command-line options, though some do not have exact equivalents here, for example `--recode-video` has to be specified via `postprocessors`. Also note that dashes are replaced with underscores.
+* __YTDL_OPTIONS__: Additional options to pass to youtube-dl, in JSON format. [See available options here](https://github.com/yt-dlp/yt-dlp/blob/master/yt_dlp/YoutubeDL.py#L183). They roughly correspond to command-line options, though some do not have exact equivalents here, for example `--recode-video` has to be specified via `postprocessors`. Also note that dashes are replaced with underscores.
+* __YTDL_OPTIONS_FILE__: A path to a JSON file that will be loaded and used for populating `YTDL_OPTIONS` above. Please note that if both `YTDL_OPTIONS_FILE` and `YTDL_OPTIONS` are specified, the options in `YTDL_OPTIONS` take precedence.
 
 The following example value for `YTDL_OPTIONS` embeds English subtitles and chapter markers (for videos that have them), and also changes the permissions on the downloaded video and sets the file modification timestamp to the date of when it was downloaded:
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Certain values can be set via environment variables, using the `-e` parameter on
 * __URL_PREFIX__: base path for the web server (for use when hosting behind a reverse proxy). Defaults to `/`.
 * __OUTPUT_TEMPLATE__: the template for the filenames of the downloaded videos, formatted according to [this spec](https://github.com/yt-dlp/yt-dlp/blob/master/README.md#output-template). Defaults to `%(title)s.%(ext)s`.
 * __OUTPUT_TEMPLATE_CHAPTER__: the template for the filenames of the downloaded videos, when split into chapters via postprocessors. Defaults to `%(title)s - %(section_number)s %(section_title)s.%(ext)s`.
-* __YTDL_OPTIONS__: Additional options to pass to youtube-dl, in JSON format. [See available options here](https://github.com/yt-dlp/yt-dlp/blob/master/yt_dlp/YoutubeDL.py#L183). They roughly correspond to command-line options, though some do not have exact equivalents here, for example `--recode-video` has to be specified via `postprocessors`. Also note that dashes are replaced with underscores.
+* __YTDL_OPTIONS__: Additional options to pass to youtube-dl, This can be path to a file or or JSON format string. [See available options here](https://github.com/yt-dlp/yt-dlp/blob/master/yt_dlp/YoutubeDL.py#L183). They roughly correspond to command-line options, though some do not have exact equivalents here, for example `--recode-video` has to be specified via `postprocessors`. Also note that dashes are replaced with underscores.
 
 The following example value for `YTDL_OPTIONS` embeds English subtitles and chapter markers (for videos that have them), and also changes the permissions on the downloaded video and sets the file modification timestamp to the date of when it was downloaded:
 

--- a/app/main.py
+++ b/app/main.py
@@ -3,7 +3,6 @@
 
 import os
 import sys
-import traceback
 from aiohttp import web
 import socketio
 import logging
@@ -15,7 +14,7 @@ from ytdl import DownloadQueueNotifier, DownloadQueue
 log = logging.getLogger('main')
 if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)
-    
+
 class Config:
     _DEFAULTS = {
         'DOWNLOAD_DIR': '.',

--- a/app/main.py
+++ b/app/main.py
@@ -39,6 +39,8 @@ class Config:
 
     def __init__(self):
         for k, v in self._DEFAULTS.items():
+            if k in os.environ:
+                log.debug(f"ENV override for {k} = {os.environ[k]}")
             setattr(self, k, os.environ[k] if k in os.environ else v)
 
         for k, v in self.__dict__.items():
@@ -64,7 +66,7 @@ class Config:
 
             assert isinstance(self.YTDL_OPTIONS, dict)
             if len(self.YTDL_OPTIONS) != 0:
-                log.info(f"Using custom yt-dlp options:\n{json.dumps(self.YTDL_OPTIONS, indent=2, ensure_ascii=False)}")
+                log.debug(f"Using custom yt-dlp options:\n{json.dumps(self.YTDL_OPTIONS, indent=2, ensure_ascii=False)}")
         except (json.decoder.JSONDecodeError, AssertionError) as e:
             log.error(f"Unable to parse YTDL_OPTIONS value. {str(e)}")
             sys.exit(1)


### PR DESCRIPTION
This PR implements a way to load yt-dlp custom options from file using the same environment variable name, i also updated the README.md to reflect the changes.

This PR closes #210 