### PR TITLE
Fix memory leak when many videos are queued

### DIFF
--- a/ui/src/app/app.component.html
+++ b/ui/src/app/app.component.html
@@ -94,7 +94,7 @@
       </tr>
     </thead>
     <tbody>
-      <tr *ngFor="let download of downloads.queue | keyvalue: asIsOrder" [class.disabled]='download.value.deleting'>
+      <tr *ngFor="let download of downloads.queue | keyvalue: asIsOrder; trackBy: identifyDownloadRow" [class.disabled]='download.value.deleting'>
         <td>
           <app-slave-checkbox [id]="download.key" [master]="queueMasterCheckbox" [checkable]="download.value"></app-slave-checkbox>
         </td>
@@ -127,7 +127,7 @@
       </tr>
     </thead>
     <tbody>
-      <tr *ngFor="let download of downloads.done | keyvalue: asIsOrder" [class.disabled]='download.value.deleting'>
+      <tr *ngFor="let download of downloads.done | keyvalue: asIsOrder; trackBy: identifyDownloadRow" [class.disabled]='download.value.deleting'>
         <td>
           <app-slave-checkbox [id]="download.key" [master]="doneMasterCheckbox" [checkable]="download.value"></app-slave-checkbox>
         </td>

--- a/ui/src/app/app.component.ts
+++ b/ui/src/app/app.component.ts
@@ -7,6 +7,7 @@ import { map, Observable, of } from 'rxjs';
 import { Download, DownloadsService, Status } from './downloads.service';
 import { MasterCheckboxComponent } from './master-checkbox.component';
 import { Formats, Format, Quality } from './formats';
+import {KeyValue} from "@angular/common";
 
 @Component({
   selector: 'app-root',
@@ -206,5 +207,9 @@ export class AppComponent implements AfterViewInit {
     }
 
     return baseDir + encodeURIComponent(download.filename);
+  }
+
+  identifyDownloadRow(index: number, row: KeyValue<string, Download>) {
+    return row.key;
   }
 }


### PR DESCRIPTION
Currently angular is re-rendering the entire download queue whenever a download's state changes. 

This is inefficient, but when combined with a long download queue the frequency of websocket progress updates causes many thousands of dom nodes to be created very quickly. This causes a large increase in memory usage, which in my experience continues to worsen until the tab is closed.

This PR adds a `trackBy` function to the `ngFor` of each half of the queue to resolve this by preventing unnecessary re-rendering.

Fixes #297 