### PR TITLE
Added support for showing when live stream will start as error message

### DIFF
--- a/app/ytdl.py
+++ b/app/ytdl.py
@@ -28,7 +28,7 @@ class DownloadQueueNotifier:
         raise NotImplementedError
 
 class DownloadInfo:
-    def __init__(self, id, title, url, quality, format, folder, custom_name_prefix):
+    def __init__(self, id, title, url, quality, format, folder, custom_name_prefix, error=None):
         self.id = id if len(custom_name_prefix) == 0 else f'{custom_name_prefix}.{id}'
         self.title = title if len(custom_name_prefix) == 0 else f'{custom_name_prefix}.{title}'
         self.url = url
@@ -38,6 +38,7 @@ class DownloadInfo:
         self.custom_name_prefix = custom_name_prefix
         self.status = self.msg = self.percent = self.speed = self.eta = None
         self.timestamp = time.time_ns()
+        self.error = error
 
 class Download:
     manager = None
@@ -86,6 +87,7 @@ class Download:
                 'outtmpl': { "default": self.output_template, "chapter": self.output_template_chapter },
                 'format': self.format,
                 'socket_timeout': 30,
+                'ignore_no_formats_error': True,
                 'progress_hooks': [put_status],
                 'postprocessor_hooks': [put_status_postprocessor],
                 **self.ytdl_opts,
@@ -216,6 +218,7 @@ class DownloadQueue:
             'quiet': True,
             'no_color': True,
             'extract_flat': True,
+            'ignore_no_formats_error': True,
             **self.config.YTDL_OPTIONS,
         }).extract_info(url, download=False)
 
@@ -246,6 +249,13 @@ class DownloadQueue:
         if not entry:
             return {'status': 'error', 'msg': "Invalid/empty data was given."}
 
+        error = None
+        if "live_status" in entry and "release_timestamp" in entry and entry.get("live_status") == "is_upcoming":
+            error = f"Live stream is scheduled to start at {time.strftime('%Y-%m-%d %H:%M:%S %Z', time.localtime(entry.get('release_timestamp')))}"
+        else:
+            if "msg" in entry:
+                error = entry["msg"]
+
         etype = entry.get('_type') or 'video'
         if etype == 'playlist':
             entries = entry['entries']
@@ -264,7 +274,7 @@ class DownloadQueue:
             return {'status': 'ok'}
         elif etype == 'video' or etype.startswith('url') and 'id' in entry and 'title' in entry:
             if not self.queue.exists(entry['id']):
-                dl = DownloadInfo(entry['id'], entry['title'], entry.get('webpage_url') or entry['url'], quality, format, folder, custom_name_prefix)
+                dl = DownloadInfo(entry['id'], entry['title'], entry.get('webpage_url') or entry['url'], quality, format, folder, custom_name_prefix, error)
                 dldirectory, error_message = self.__calc_download_path(quality, format, folder)
                 if error_message is not None:
                     return error_message

--- a/app/ytdl.py
+++ b/app/ytdl.py
@@ -8,6 +8,7 @@ import multiprocessing
 import logging
 import re
 from dl_formats import get_format, get_opts, AUDIO_FORMATS
+from datetime import datetime
 
 log = logging.getLogger('ytdl')
 
@@ -251,7 +252,8 @@ class DownloadQueue:
 
         error = None
         if "live_status" in entry and "release_timestamp" in entry and entry.get("live_status") == "is_upcoming":
-            error = f"Live stream is scheduled to start at {time.strftime('%Y-%m-%d %H:%M:%S %Z', time.localtime(entry.get('release_timestamp')))}"
+            dt_ts = datetime.fromtimestamp(entry.get("release_timestamp")).strftime('%Y-%m-%d %H:%M:%S %z')
+            error = f"Live stream is scheduled to start at {dt_ts}"
         else:
             if "msg" in entry:
                 error = entry["msg"]

--- a/app/ytdl.py
+++ b/app/ytdl.py
@@ -29,7 +29,7 @@ class DownloadQueueNotifier:
         raise NotImplementedError
 
 class DownloadInfo:
-    def __init__(self, id, title, url, quality, format, folder, custom_name_prefix, error=None):
+    def __init__(self, id, title, url, quality, format, folder, custom_name_prefix, error):
         self.id = id if len(custom_name_prefix) == 0 else f'{custom_name_prefix}.{id}'
         self.title = title if len(custom_name_prefix) == 0 else f'{custom_name_prefix}.{title}'
         self.url = url

--- a/ui/src/app/app.component.html
+++ b/ui/src/app/app.component.html
@@ -167,8 +167,7 @@
           <button *ngIf="download.value.status == 'error'" type="button" class="btn btn-link" (click)="retryDownload(download.key, download.value)"><fa-icon [icon]="faRedoAlt"></fa-icon></button>
         </td>
         <td>
-          <a *ngIf="download.value.filename; else no_download" href="{{buildDownloadLink(download.value)}}" download><fa-icon [icon]="faDownload"></fa-icon></a>
-          <ng-template #no_download><a href="#"><fa-icon [icon]="faDownload"></fa-icon></a></ng-template>
+          <a *ngIf="download.value.filename" href="{{buildDownloadLink(download.value)}}" download><fa-icon [icon]="faDownload"></fa-icon></a>
         </td>
         <td>
           <a href="{{download.value.url}}" target="_blank"><fa-icon [icon]="faExternalLinkAlt"></fa-icon></a>

--- a/ui/src/app/app.component.html
+++ b/ui/src/app/app.component.html
@@ -156,14 +156,19 @@
             <fa-icon *ngIf="download.value.status == 'finished'" [icon]="faCheckCircle" class="text-success"></fa-icon>
             <fa-icon *ngIf="download.value.status == 'error'" [icon]="faTimesCircle" class="text-danger"></fa-icon>
           </div>
-          <span ngbTooltip="{{download.value.msg}}"><a *ngIf="!!download.value.filename; else noDownloadLink" href="{{buildDownloadLink(download.value)}}" target="_blank">{{ download.value.title }}</a></span>
-          <ng-template #noDownloadLink>{{ download.value.title }}</ng-template>
+          <span ngbTooltip="{{download.value.msg}} | {{download.value.error}}"><a *ngIf="!!download.value.filename; else noDownloadLink" href="{{buildDownloadLink(download.value)}}" target="_blank">{{ download.value.title }}</a></span>
+          <ng-template #noDownloadLink>
+            {{download.value.title}}
+            <span *ngIf="download.value.msg"><br>{{download.value.msg}}</span>
+            <span *ngIf="download.value.error"><br>Error: {{download.value.error}}</span>
+          </ng-template>
         </td>
         <td>
           <button *ngIf="download.value.status == 'error'" type="button" class="btn btn-link" (click)="retryDownload(download.key, download.value)"><fa-icon [icon]="faRedoAlt"></fa-icon></button>
         </td>
         <td>
-          <a *ngIf="!!download.value.filename; else noDownloadLink" href="{{buildDownloadLink(download.value)}}" download><fa-icon [icon]="faDownload"></fa-icon></a>
+          <a *ngIf="download.value.filename; else no_download" href="{{buildDownloadLink(download.value)}}" download><fa-icon [icon]="faDownload"></fa-icon></a>
+          <ng-template #no_download><a href="#"><fa-icon [icon]="faDownload"></fa-icon></a></ng-template>
         </td>
         <td>
           <a href="{{download.value.url}}" target="_blank"><fa-icon [icon]="faExternalLinkAlt"></fa-icon></a>


### PR DESCRIPTION
Hi, 

This pull request add support for showing when the live stream will start as error message.

![image](https://github.com/alexta69/metube/assets/1621552/f33920d6-b48b-4227-af9b-3ce4d530381a)

to support getting past the format error as not yet live stream throw an error i had to use `ignore_no_formats_error` option. 