### PR TITLE
Fix the behavior when auto-start option is not explicitly passed

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -120,6 +120,8 @@ async def add(request):
     auto_start = post.get('auto_start')
     if custom_name_prefix is None:
         custom_name_prefix = ''
+    if auto_start is None:
+        auto_start = True
     status = await dqueue.add(url, quality, format, folder, custom_name_prefix, auto_start)
     return web.Response(text=serializer.encode(status))
 


### PR DESCRIPTION
When auto-start is not explicitly set, it will automatically start downloading by default.