### PR TITLE
Pass paths also when extracting metadata

### DIFF
--- a/app/ytdl.py
+++ b/app/ytdl.py
@@ -222,6 +222,7 @@ class DownloadQueue:
             'no_color': True,
             'extract_flat': True,
             'ignore_no_formats_error': True,
+            'paths': {"home": self.config.DOWNLOAD_DIR, "temp": self.config.TEMP_DIR},
             **self.config.YTDL_OPTIONS,
         }).extract_info(url, download=False)
 


### PR DESCRIPTION
Fixes #363 

In some cases, such as when writing thumbnails, this call can still cause creation of non-temporary files on disk which should then also be placed in DOWNLOAD_DIR