### PR TITLE
Fix PWA manifest for relative paths

### DIFF
--- a/ui/src/custom-service-worker.js
+++ b/ui/src/custom-service-worker.js
@@ -1,5 +1,5 @@
-const URL_PATTERN =
-  /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/gi;
+/* RegExp pattern to match URLs in the shared target text (apps often share additional text, not only URLs) */
+const URL_PATTERN = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/gi;
 
 self.addEventListener("fetch", (event) => {
   if (event.request.method === "GET") {
@@ -9,12 +9,13 @@ self.addEventListener("fetch", (event) => {
       const urlRegExp = new RegExp(URL_PATTERN);
       const sharedText = url.searchParams.get("text");
       const matches = [...sharedText.matchAll(urlRegExp)].map((m) => m[0]);
+      const basePath = url.pathname.split("/").slice(0, -1).join("/");
 
       event.respondWith(
         (async () => {
           await Promise.all(
             matches.map((url) => {
-              return fetch("/add", {
+              return fetch(`${basePath}/add`, {
                 method: "POST",
                 headers: {
                   "Content-Type": "application/json",
@@ -28,7 +29,7 @@ self.addEventListener("fetch", (event) => {
               });
             })
           );
-          return Response.redirect("/", 303);
+          return Response.redirect(basePath, 303);
         })()
       );
     }

--- a/ui/src/manifest.webmanifest
+++ b/ui/src/manifest.webmanifest
@@ -5,7 +5,7 @@
   "background_color": "#fafafa",
   "display": "standalone",
   "scope": "./",
-  "start_url": "/?utm_source=homescreen",
+  "start_url": "./?utm_source=homescreen",
   "icons": [
     {
       "src": "assets/icons/android-chrome-192x192.png",
@@ -19,7 +19,7 @@
     }
   ],
   "share_target": {
-    "action": "/share-target",
+    "action": "./share-target",
     "method": "GET",
     "params": {
       "text": "text"


### PR DESCRIPTION
In my recent PR for the PWA share target I made a mistake with absolute instead of relative paths. This lead to incorrect behavior with URL paths other than root.
This PR fixes that and adds a short comment to the URL RegExp as discussed (https://github.com/alexta69/metube/pull/361#discussion_r1438685903).