### PR TITLE
Support basic auth in Chrome bookmarklet

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ __Firefox:__ contributed by [nanocortex](https://github.com/nanocortex). You can
 GitHub doesn't allow embedding JavaScript as a link, so the bookmarklet has to be created manually by copying the following code to a new bookmark you create on your bookmarks bar. Change the hostname in the URL below to point to your MeTube instance.
 
 ```javascript
-javascript:!function(){xhr=new XMLHttpRequest();xhr.open("POST","https://metube.domain.com/add");xhr.send(JSON.stringify({"url":document.location.href,"quality":"best"}));xhr.onload=function(){if(xhr.status==200){alert("Sent to metube!")}else{alert("Send to metube failed. Check the javascript console for clues.")}}}();
+javascript:!function(){xhr=new XMLHttpRequest();xhr.open("POST","https://metube.domain.com/add");xhr.withCredentials=true;xhr.send(JSON.stringify({"url":document.location.href,"quality":"best"}));xhr.onload=function(){if(xhr.status==200){alert("Sent to metube!")}else{alert("Send to metube failed. Check the javascript console for clues.")}}}();
 ```
 
 [shoonya75](https://github.com/shoonya75) has contributed a Firefox version:


### PR DESCRIPTION
Updated the MeTube bookmarklet to include `xhr.withCredentials=true` in the AJAX request. This allows the bookmarklet to work when MeTube is behind basic auth.

Only applied this change to the Chrome version of the bookmarklet since that is the environment I was able to test in.

Thank you for metube 📺