### PR TITLE
Fix basic auth not asking for credentials

### DIFF
--- a/ui/src/index.html
+++ b/ui/src/index.html
@@ -11,7 +11,7 @@
   <meta name="msapplication-config" content="assets/icons/browserconfig.xml">
   <link rel="shortcut icon" href="favicon.ico">
   <meta name="msapplication-TileColor" content="#da532c">
-  <link rel="manifest" href="manifest.webmanifest">
+  <link rel="manifest" href="manifest.webmanifest" crossorigin="use-credentials">
   <meta name="theme-color" content="#212529">
 </head>
 <body>


### PR DESCRIPTION
Fixes: #470
I tested both Firefox and Chromium, with and without proxy.
After changing the manifest origin setting, on Firefox everything works correctly.
Sadly, Chromium still has problems, issues are open for years now.
In any case, the fix shouldn't have impact on users without basic auth and respects the spec.
