### PR TITLE
inject manifest attribute after building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN sed -i 's/\r$//g' docker-entrypoint.sh && \
 
 COPY app ./app
 COPY --from=builder /metube/dist/metube ./ui/dist/metube
+RUN sed -i 's/webmanifest"/webmanifest" crossorigin="use-credentials"/' ./ui/dist/metube/index.html
 
 ENV UID=1000
 ENV GID=1000

--- a/ui/src/index.html
+++ b/ui/src/index.html
@@ -11,7 +11,7 @@
   <meta name="msapplication-config" content="assets/icons/browserconfig.xml">
   <link rel="shortcut icon" href="favicon.ico">
   <meta name="msapplication-TileColor" content="#da532c">
-  <link rel="manifest" href="manifest.webmanifest" crossorigin="use-credentials">
+  <link rel="manifest" href="manifest.webmanifest">
   <meta name="theme-color" content="#212529">
 </head>
 <body>


### PR DESCRIPTION
Hi, sorry to bother you again. Looks like I underestimated web development quirks...
When I tested my change by editing the compiled index.html, everything worked as described.
Testing the latest release, the index.html and manifest is cached by the browser, which again causes it to omit the basic auth challenge.
Looks like the hash-based cache-busting mechanic bit me here. The solution seems to be to introduce the manifest attribute after building.
Or changing the hash for index.html in ngsw.json after building.
