### PR TITLE
removed version line from Docker Compose YAML section

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ docker run -d -p 8081:8081 -v /path/to/downloads:/downloads ghcr.io/alexta69/met
 ## Run using docker-compose
 
 ```yaml
-version: "3"
 services:
   metube:
     image: ghcr.io/alexta69/metube


### PR DESCRIPTION
Removed line `version: "3"` from Docker Compose YAML example. Specifying version is now obsolete and will throw a warning message when launching docker compose file.