### PR TITLE
Responsive design improvements

### DIFF
--- a/ui/src/app/app.component.html
+++ b/ui/src/app/app.component.html
@@ -23,7 +23,7 @@
                 data-bs-display="static">
           <fa-icon [icon]="activeTheme.icon"></fa-icon>
         </button>
-        <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="theme-select">
+        <ul class="dropdown-menu dropdown-menu-end position-absolute" aria-labelledby="theme-select">
           <li *ngFor="let theme of themes">
             <button type="button" class="dropdown-item d-flex align-items-center" [ngClass]="{'active' : activeTheme == theme}" (click)="themeChanged(theme)">
               <span class="me-2 opacity-50">
@@ -50,7 +50,7 @@
         </div>
       </div>
       <div class="row">
-        <div class="col-md-3 add-url-component">
+        <div class="col-md-6 col-lg-3 add-url-component">
           <div class="input-group">
             <span class="input-group-text">Quality</span>
             <select class="form-select" name="quality" [(ngModel)]="quality" (change)="qualityChanged()" [disabled]="addInProgress || downloads.loading">
@@ -58,7 +58,7 @@
             </select>
           </div>
         </div>
-        <div class="col-md-3 add-url-component">
+        <div class="col-md-6 col-lg-3 add-url-component">
           <div class="input-group">
             <span class="input-group-text">Format</span>
             <select class="form-select" name="format" [(ngModel)]="format" (change)="formatChanged()" [disabled]="addInProgress || downloads.loading">
@@ -66,7 +66,7 @@
             </select>
           </div>
         </div>
-        <div class="col-md-3 add-url-component">
+        <div class="col-md-6 col-lg-3 add-url-component">
           <div class="input-group">
             <span class="input-group-text">Auto Start</span>
             <select class="form-select" name="autoStart" [(ngModel)]="autoStart" (change)="autoStartChanged()" [disabled]="addInProgress || downloads.loading">
@@ -75,7 +75,7 @@
             </select>
           </div>
         </div>
-        <div class="col-md-3 add-url-component">
+        <div class="col-md-6 col-lg-3 add-url-component">
           <div [attr.class]="showAdvanced() ? 'btn-group add-url-group' : 'add-url-group'" ngbDropdown #advancedDropdown="ngbDropdown" display="dynamic" placement="bottom-end">
             <button class="btn btn-primary add-url" type="submit" (click)="addDownload()" [disabled]="addInProgress || downloads.loading">
               <span class="spinner-border spinner-border-sm" role="status" id="add-spinner" *ngIf="addInProgress"></span>
@@ -95,19 +95,19 @@
                   <input type="text" autocomplete="off" spellcheck="false" class="form-control" placeholder="Default" name="customNamePrefix" [(ngModel)]="customNamePrefix" [disabled]="addInProgress || downloads.loading">
                 </div>
                 <div class="add-url-component">
-                  <div class="row align-items-center">
-                    <div class="col-6">
-                      <div class="input-group ms-1">
-                      <div class="form-check form-switch">
-                        <input class="form-check-input" type="checkbox" role="switch" name="playlistStrictMode" [(ngModel)]="playlistStrictMode" [disabled]="addInProgress || downloads.loading">
-                        <label class="form-check-label">Strict Playlist mode</label>
-                      </div>
-                    </div>
-                    </div>
-                    <div class="col-6">
+                  <div class="row align-items-center gy-2">
+                    <div class="col-12 col-md-6 order-md-2">
                       <div class="input-group">
                         <span class="input-group-text">Items limit</span>
                         <input type="number" min="0" autocomplete="off" class="form-control" placeholder="Default" name="playlistItemLimit" (keydown)="isNumber($event)" [(ngModel)]="playlistItemLimit" [disabled]="addInProgress || downloads.loading">
+                      </div>
+                    </div>
+                    <div class="col-12 col-md-6 order-md-1">
+                      <div class="input-group ms-1">
+                        <div class="form-check form-switch">
+                          <input class="form-check-input" type="checkbox" role="switch" name="playlistStrictMode" [(ngModel)]="playlistStrictMode" [disabled]="addInProgress || downloads.loading">
+                          <label class="form-check-label">Strict Playlist mode</label>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -123,96 +123,98 @@
   <div *ngIf="downloads.loading" class="alert alert-info" role="alert">
     Connecting to server...
   </div>
-    <div class="metube-section-header">Downloading</div>
-  <table class="table">
-    <thead>
-      <tr>
-        <th scope="col" style="width: 1rem;">
-          <app-master-checkbox #queueMasterCheckbox [id]="'queue'" [list]="downloads.queue" (changed)="queueSelectionChanged($event)"></app-master-checkbox>
-        </th>
-        <th scope="col">
-          <button type="button" class="btn btn-link text-decoration-none px-0 me-4" disabled #queueDelSelected (click)="delSelectedDownloads('queue')"><fa-icon [icon]="faTrashAlt"></fa-icon>&nbsp; Cancel selected</button>
-        </th>
-        <th scope="col" style="width: 14rem;"></th>
-        <th scope="col" style="width: 8rem;">Speed</th>
-        <th scope="col" style="width: 7rem;">ETA</th>
-        <th scope="col" style="width: 2rem;"></th>
-        <th scope="col" style="width: 2rem;"></th>
-        <th scope="col" style="width: 2rem;"></th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr *ngFor="let download of downloads.queue | keyvalue: asIsOrder; trackBy: identifyDownloadRow" [class.disabled]='download.value.deleting'>
-        <td>
-          <app-slave-checkbox [id]="download.key" [master]="queueMasterCheckbox" [checkable]="download.value"></app-slave-checkbox>
-        </td>
-        <td title="{{ download.value.filename }}">{{ download.value.title }}</td>
-        <td><ngb-progressbar height="1.5rem" [showValue]="download.value.status != 'preparing'" [striped]="download.value.status == 'preparing'" [animated]="download.value.status == 'preparing'" type="success" [value]="download.value.status == 'preparing' ? 100 : download.value.percent | number:'1.0-0'"></ngb-progressbar></td>
-        <td>{{ download.value.speed | speed }}</td>
-        <td>{{ download.value.eta | eta }}</td>
-        <td>
-          <button *ngIf="download.value.status === 'pending'" type="button" class="btn btn-link" (click)="downloadItemByKey(download.key)"><fa-icon [icon]="faDownload"></fa-icon></button>
-        </td>
-        <td><button type="button" class="btn btn-link" (click)="delDownload('queue', download.key)"><fa-icon [icon]="faTrashAlt"></fa-icon></button></td>
-        <td><a href="{{download.value.url}}" target="_blank"><fa-icon [icon]="faExternalLinkAlt"></fa-icon></a></td>
-      </tr>
-    </tbody>
-  </table>
+  <div class="metube-section-header">Downloading</div>
+  <div class="px-2 py-3 border-bottom">
+    <button type="button" class="btn btn-link text-decoration-none px-0 me-4" disabled #queueDelSelected (click)="delSelectedDownloads('queue')"><fa-icon [icon]="faTrashAlt"></fa-icon>&nbsp; Cancel selected</button>
+  </div>
+  <div class="overflow-auto">
+    <table class="table">
+      <thead>
+        <tr>
+          <th scope="col" style="width: 1rem;">
+            <app-master-checkbox #queueMasterCheckbox [id]="'queue'" [list]="downloads.queue" (changed)="queueSelectionChanged($event)"></app-master-checkbox>
+          </th>
+          <th scope="col">Video</th>
+          <th scope="col" style="width: 8rem;">Speed</th>
+          <th scope="col" style="width: 7rem;">ETA</th>
+          <th scope="col" style="width: 6rem;"></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let download of downloads.queue | keyvalue: asIsOrder; trackBy: identifyDownloadRow" [class.disabled]='download.value.deleting'>
+          <td>
+            <app-slave-checkbox [id]="download.key" [master]="queueMasterCheckbox" [checkable]="download.value"></app-slave-checkbox>
+          </td>
+          <td title="{{ download.value.filename }}">
+            <div class="d-flex flex-column flex-sm-row align-items-center row-gap-2 column-gap-3">
+              <div>{{ download.value.title }}</div>
+              <ngb-progressbar height="1.5rem" [showValue]="download.value.status != 'preparing'" [striped]="download.value.status == 'preparing'" [animated]="download.value.status == 'preparing'" type="success" [value]="download.value.status == 'preparing' ? 100 : download.value.percent | number:'1.0-0'" class="download-progressbar"></ngb-progressbar>
+            </div>
+          </td>
+          <td>{{ download.value.speed | speed }}</td>
+          <td>{{ download.value.eta | eta }}</td>
+          <td>
+            <div class="d-flex">
+              <button *ngIf="download.value.status === 'pending'" type="button" class="btn btn-link" (click)="downloadItemByKey(download.key)"><fa-icon [icon]="faDownload"></fa-icon></button>
+              <button type="button" class="btn btn-link" (click)="delDownload('queue', download.key)"><fa-icon [icon]="faTrashAlt"></fa-icon></button>
+              <a href="{{download.value.url}}" target="_blank" class="btn btn-link"><fa-icon [icon]="faExternalLinkAlt"></fa-icon></a>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
 
   <div class="metube-section-header">Completed</div>
-  <table class="table">
-    <thead>
-      <tr>
-        <th scope="col" style="width: 1rem;">
-          <app-master-checkbox #doneMasterCheckbox [id]="'done'" [list]="downloads.done" (changed)="doneSelectionChanged($event)"></app-master-checkbox>
-        </th>
-        <th scope="col">
-          <button type="button" class="btn btn-link text-decoration-none px-0 me-4" disabled #doneDelSelected (click)="delSelectedDownloads('done')"><fa-icon [icon]="faTrashAlt"></fa-icon>&nbsp; Clear selected</button>
-          <button type="button" class="btn btn-link text-decoration-none px-0 me-4" disabled #doneClearCompleted (click)="clearCompletedDownloads()"><fa-icon [icon]="faCheckCircle"></fa-icon>&nbsp; Clear completed</button>
-          <button type="button" class="btn btn-link text-decoration-none px-0 me-4" disabled #doneClearFailed (click)="clearFailedDownloads()"><fa-icon [icon]="faTimesCircle"></fa-icon>&nbsp; Clear failed</button>
-          <button type="button" class="btn btn-link text-decoration-none px-0 me-4" disabled #doneRetryFailed (click)="retryFailedDownloads()"><fa-icon [icon]="faRedoAlt"></fa-icon>&nbsp; Retry failed</button>
-        </th>
-        <th scope="col" >File Size</th>
-        <th scope="col" style="width: 2rem;"></th>
-        <th scope="col" style="width: 2rem;"></th>
-        <th scope="col" style="width: 2rem;"></th>
-        <th scope="col" style="width: 2rem;"></th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr *ngFor="let download of downloads.done | keyvalue: asIsOrder; trackBy: identifyDownloadRow" [class.disabled]='download.value.deleting'>
-        <td>
-          <app-slave-checkbox [id]="download.key" [master]="doneMasterCheckbox" [checkable]="download.value"></app-slave-checkbox>
-        </td>
-        <td>
-          <div style="display: inline-block; width: 1.5rem;">
-            <fa-icon *ngIf="download.value.status == 'finished'" [icon]="faCheckCircle" class="text-success"></fa-icon>
-            <fa-icon *ngIf="download.value.status == 'error'" [icon]="faTimesCircle" class="text-danger"></fa-icon>
-          </div>
-          <span ngbTooltip="{{download.value.msg}} | {{download.value.error}}"><a *ngIf="!!download.value.filename; else noDownloadLink" href="{{buildDownloadLink(download.value)}}" target="_blank">{{ download.value.title }}</a></span>
-          <ng-template #noDownloadLink>
-            {{download.value.title}}
-            <span *ngIf="download.value.msg"><br>{{download.value.msg}}</span>
-            <span *ngIf="download.value.error"><br>Error: {{download.value.error}}</span>
-          </ng-template>
-        </td>
-        <td>
-          <span *ngIf="download.value.size">{{ download.value.size | fileSize }}</span>
-        </td>
-        <td>
-          <button *ngIf="download.value.status == 'error'" type="button" class="btn btn-link" (click)="retryDownload(download.key, download.value)"><fa-icon [icon]="faRedoAlt"></fa-icon></button>
-        </td>
-        <td>
-          <a *ngIf="download.value.filename" href="{{buildDownloadLink(download.value)}}" download><fa-icon [icon]="faDownload"></fa-icon></a>
-        </td>
-        <td>
-          <a href="{{download.value.url}}" target="_blank"><fa-icon [icon]="faExternalLinkAlt"></fa-icon></a>
-        </td>
-        <td>
-          <button type="button" class="btn btn-link" (click)="delDownload('done', download.key)"><fa-icon [icon]="faTrashAlt"></fa-icon></button>
-        </td>
-      </tr>
-    </tbody>
-  </table>
+  <div class="px-2 py-3 border-bottom">
+    <button type="button" class="btn btn-link text-decoration-none px-0 me-4" disabled #doneDelSelected (click)="delSelectedDownloads('done')"><fa-icon [icon]="faTrashAlt"></fa-icon>&nbsp; Clear selected</button>
+    <button type="button" class="btn btn-link text-decoration-none px-0 me-4" disabled #doneClearCompleted (click)="clearCompletedDownloads()"><fa-icon [icon]="faCheckCircle"></fa-icon>&nbsp; Clear completed</button>
+    <button type="button" class="btn btn-link text-decoration-none px-0 me-4" disabled #doneClearFailed (click)="clearFailedDownloads()"><fa-icon [icon]="faTimesCircle"></fa-icon>&nbsp; Clear failed</button>
+    <button type="button" class="btn btn-link text-decoration-none px-0 me-4" disabled #doneRetryFailed (click)="retryFailedDownloads()"><fa-icon [icon]="faRedoAlt"></fa-icon>&nbsp; Retry failed</button>
+  </div>
+  <div class="overflow-auto">
+    <table class="table">
+      <thead>
+        <tr>
+          <th scope="col" style="width: 1rem;">
+            <app-master-checkbox #doneMasterCheckbox [id]="'done'" [list]="downloads.done" (changed)="doneSelectionChanged($event)"></app-master-checkbox>
+          </th>
+          <th scope="col">Video</th>
+          <th scope="col">File Size</th>
+          <th scope="col" style="width: 8rem;"></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let download of downloads.done | keyvalue: asIsOrder; trackBy: identifyDownloadRow" [class.disabled]='download.value.deleting'>
+          <td>
+            <app-slave-checkbox [id]="download.key" [master]="doneMasterCheckbox" [checkable]="download.value"></app-slave-checkbox>
+          </td>
+          <td>
+            <div style="display: inline-block; width: 1.5rem;">
+              <fa-icon *ngIf="download.value.status == 'finished'" [icon]="faCheckCircle" class="text-success"></fa-icon>
+              <fa-icon *ngIf="download.value.status == 'error'" [icon]="faTimesCircle" class="text-danger"></fa-icon>
+            </div>
+            <span ngbTooltip="{{download.value.msg}} | {{download.value.error}}"><a *ngIf="!!download.value.filename; else noDownloadLink" href="{{buildDownloadLink(download.value)}}" target="_blank">{{ download.value.title }}</a></span>
+            <ng-template #noDownloadLink>
+              {{download.value.title}}
+              <span *ngIf="download.value.msg"><br>{{download.value.msg}}</span>
+              <span *ngIf="download.value.error"><br>Error: {{download.value.error}}</span>
+            </ng-template>
+          </td>
+          <td>
+            <span *ngIf="download.value.size">{{ download.value.size | fileSize }}</span>
+          </td>
+          <td>
+            <div class="d-flex">
+              <button *ngIf="download.value.status == 'error'" type="button" class="btn btn-link" (click)="retryDownload(download.key, download.value)"><fa-icon [icon]="faRedoAlt"></fa-icon></button>
+              <a *ngIf="download.value.filename" href="{{buildDownloadLink(download.value)}}" download class="btn btn-link"><fa-icon [icon]="faDownload"></fa-icon></a>
+              <a href="{{download.value.url}}" target="_blank" class="btn btn-link"><fa-icon [icon]="faExternalLinkAlt"></fa-icon></a>
+              <button type="button" class="btn btn-link" (click)="delDownload('done', download.key)"><fa-icon [icon]="faTrashAlt"></fa-icon></button>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
 
 </main><!-- /.container -->

--- a/ui/src/app/app.component.sass
+++ b/ui/src/app/app.component.sass
@@ -17,6 +17,7 @@ button.add-url
 
 .folder-dropdown-menu
     width: 500px
+    max-width: calc(100vw - 3rem)
 
 .folder-dropdown-menu .input-group
     display: flex
@@ -48,6 +49,7 @@ th
     border-top: 0
     border-bottom-width: 3px !important
     vertical-align: middle !important
+    white-space: nowrap
 
 td
     vertical-align: middle
@@ -59,3 +61,7 @@ td
 .form-switch
   input
     margin-top: 5px
+
+.download-progressbar
+    width: 12rem
+    margin-left: auto


### PR DESCRIPTION
This pull request implements a few layout and style tweaks to the UI to improve usability on smaller screen sizes. 

- Fixed theme dropdown being positioned incorrectly at small screen sizes
- Additional breakpoint for the 3 dropdowns and button below the URL input
- Fixed advanced options dropdown overflowing past the left edge of the page
- Tweaked advanced options dropdown contents layout to put the switch at the bottom and give the input next to it enough room
- Moved buttons that were the headers of their tables to give them more room so that they no longer wrap awkwardly inside the table
- Moved buttons at the end of each table row into a shared cell to make their spacing consistent
- Download progress bar now appears below the video title at small screen sizes