### PR TITLE
fix: provide default value for title when absent

### DIFF
--- a/app/ytdl.py
+++ b/app/ytdl.py
@@ -293,7 +293,7 @@ class DownloadQueue:
         elif etype == 'video' or etype.startswith('url') and 'id' in entry and 'title' in entry:
             log.debug('Processing as a video')
             if not self.queue.exists(entry['id']):
-                dl = DownloadInfo(entry['id'], entry['title'], entry.get('webpage_url') or entry['url'], quality, format, folder, custom_name_prefix, error)
+                dl = DownloadInfo(entry['id'], entry.get('title') or entry['id'], entry.get('webpage_url') or entry['url'], quality, format, folder, custom_name_prefix, error)
                 dldirectory, error_message = self.__calc_download_path(quality, format, folder)
                 if error_message is not None:
                     return error_message


### PR DESCRIPTION
Issue: When trying to download any series from tubitv, there is an error that appears and I'm not able to download the series. I am able to download individual videos from within the playlist.

Reason: When creating the DownloadInfo object, there is an error thrown due to the title not existing on the entry. Adding a fallback fixes this error and allows things to proceed as expected. 