### PR TITLE
Exclude index.html from service worker

### DIFF
--- a/ui/ngsw-config.json
+++ b/ui/ngsw-config.json
@@ -8,7 +8,6 @@
       "resources": {
         "files": [
           "/favicon.ico",
-          "/index.html",
           "/manifest.webmanifest",
           "/*.css",
           "/*.js"


### PR DESCRIPTION
The Service Worker caches the index.html file. When MeTube is behind an auth proxy, the browser opens index.html from the cache instead of returning a 401 status(in the case of basic auth) or redirecting for OAuth2 forward proxies(such as Authelia, Authentik, OAuth2-Proxy, etc).

This PR excludes index.html from the Service Worker, ensuring that the first request is always fresh and returns the correct status code.

This addresses the following issues:
- https://github.com/alexta69/metube/issues/478
- https://github.com/alexta69/metube/issues/459