### PR TITLE
Adds 'pending' to response for GET /history

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -165,12 +165,14 @@ async def start(request):
 
 @routes.get(config.URL_PREFIX + 'history')
 async def history(request):
-    history = { 'done': [], 'queue': []}
+    history = { 'done': [], 'queue': [], 'pending': []}
 
     for _ ,v in dqueue.queue.saved_items():
         history['queue'].append(v)
     for _ ,v in dqueue.done.saved_items():
         history['done'].append(v)
+    for _ ,v in dqueue.pending.saved_items():
+        history['pending'].append(v)
 
     return web.Response(text=serializer.encode(history))
 


### PR DESCRIPTION
Allows for some additional integration opportunities by including "pending" items in the json response to GET /history.
It doesn't look like it'll have any impact on the js app because that uses websockets and not the REST API, but this is very useful if you add a *large* number of items to pending - either accidentally or on purpose, and need a way to manage them.