### PR TITLE
Add tini as entrypoint in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY Pipfile* docker-entrypoint.sh ./
 # Install dependencies
 RUN sed -i 's/\r$//g' docker-entrypoint.sh && \
     chmod +x docker-entrypoint.sh && \
-    apk add --update ffmpeg aria2 coreutils shadow su-exec curl && \
+    apk add --update ffmpeg aria2 coreutils shadow su-exec curl tini && \
     apk add --update --virtual .build-deps gcc g++ musl-dev && \
     pip install --no-cache-dir pipenv && \
     pipenv install --system --deploy --clear && \
@@ -37,4 +37,4 @@ ENV STATE_DIR /downloads/.metube
 ENV TEMP_DIR /downloads
 VOLUME /downloads
 EXPOSE 8081
-CMD [ "./docker-entrypoint.sh" ]
+ENTRYPOINT ["/sbin/tini", "-g", "--", "./docker-entrypoint.sh"]


### PR DESCRIPTION
I noticed that the docker container was slow to shut down, just a little over 10 seconds. This is a strong indication that the sigint signal is not getting forwarded to subprocesses properly, and the container only shuts down once it receives sigkill. This is easily fixed by using `tini` as the entrypoint, which will, among other things, handle the signals properly. 

Here is an example before and after adding `tini`:
![250112_12h22m07s_screenshot](https://github.com/user-attachments/assets/bf39d43d-0459-429c-b409-6dbc6e859600)
