### PR TITLE
display yt-dlp version in webui

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -12,6 +12,7 @@ import json
 import pathlib
 
 from ytdl import DownloadQueueNotifier, DownloadQueue
+from yt_dlp.version import __version__ as yt_dlp_version
 
 log = logging.getLogger('main')
 
@@ -230,6 +231,10 @@ def robots(request):
             text="User-agent: *\nDisallow: /download/\nDisallow: /audio_download/\n"
         )
     return response
+
+@routes.get(config.URL_PREFIX + 'version')
+def version(request):
+    return web.json_response({"version": yt_dlp_version})
 
 if config.URL_PREFIX != '/':
     @routes.get('/')

--- a/ui/src/app/app.component.html
+++ b/ui/src/app/app.component.html
@@ -217,5 +217,7 @@
       </tbody>
     </table>
   </div>
-
+  <div class="footer text-center px-2">
+    <small *ngIf="versionInfo">{{ versionInfo }}</small>
+  </div>
 </main><!-- /.container -->

--- a/ui/src/app/app.component.ts
+++ b/ui/src/app/app.component.ts
@@ -1,4 +1,5 @@
 import { Component, ViewChild, ElementRef, AfterViewInit } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
 import { faTrashAlt, faCheckCircle, faTimesCircle, IconDefinition } from '@fortawesome/free-regular-svg-icons';
 import { faRedoAlt, faSun, faMoon, faCircleHalfStroke, faCheck, faExternalLinkAlt, faDownload } from '@fortawesome/free-solid-svg-icons';
 import { CookieService } from 'ngx-cookie-service';
@@ -30,6 +31,7 @@ export class AppComponent implements AfterViewInit {
   themes: Theme[] = Themes;
   activeTheme: Theme;
   customDirs$: Observable<string[]>;
+  versionInfo: string | null = null;
 
   @ViewChild('queueMasterCheckbox') queueMasterCheckbox: MasterCheckboxComponent;
   @ViewChild('queueDelSelected') queueDelSelected: ElementRef;
@@ -51,7 +53,7 @@ export class AppComponent implements AfterViewInit {
   faDownload = faDownload;
   faExternalLinkAlt = faExternalLinkAlt;
 
-  constructor(public downloads: DownloadsService, private cookieService: CookieService) {
+  constructor(public downloads: DownloadsService, private cookieService: CookieService, private http: HttpClient) {
     this.format = cookieService.get('metube_format') || 'any';
     // Needs to be set or qualities won't automatically be set
     this.setQualities()
@@ -90,6 +92,7 @@ export class AppComponent implements AfterViewInit {
       this.doneClearFailed.nativeElement.disabled = failed === 0;
       this.doneRetryFailed.nativeElement.disabled = failed === 0;
     });
+    this.fetchVersionInfo();
   }
 
   // workaround to allow fetching of Map values in the order they were inserted
@@ -276,5 +279,19 @@ export class AppComponent implements AfterViewInit {
     if (charCode > 31 && (charCode < 48 || charCode > 57)) {
       event.preventDefault();
     }
+  }
+
+  fetchVersionInfo(): void {
+    const baseUrl = `${window.location.origin}${window.location.pathname.replace(/\/[^\/]*$/, '/')}`;
+    const versionUrl = `${baseUrl}version`;
+    this.http.get<{ version: string}>(versionUrl)
+      .subscribe({
+        next: (data) => {
+          this.versionInfo = `yt-dlp version: ${data.version}`;
+        },
+        error: () => {
+          this.versionInfo = '';
+        }
+      });
   }
 }


### PR DESCRIPTION
In order to clearly know the current yt-dlp version in use and to distinguish whether the issue is known to yt-dlp, the current yt-dlp version number is displayed at the bottom of the web page.

![image](https://github.com/user-attachments/assets/3dd15aa9-7438-41cc-bf02-333089f73fae)
