### PR TITLE
Fix: Restore queue when container restarted from old queue file

### DIFF
--- a/app/ytdl.py
+++ b/app/ytdl.py
@@ -238,7 +238,7 @@ class DownloadQueue:
 
     async def __import_queue(self):
         for k, v in self.queue.saved_items():
-            await self.add(v.url, v.quality, v.format, v.folder, v.custom_name_prefix, v.playlist_strict_mode, v.playlist_item_limit)
+            await self.add(v.url, v.quality, v.format, v.folder, v.custom_name_prefix, getattr(v, 'playlist_strict_mode', False), getattr(v, 'playlist_item_limit', 0))
 
     async def initialize(self):
         log.info("Initializing DownloadQueue")


### PR DESCRIPTION
In case the user tries to restart the container with an updated container but an old queue file, the system checks if the object contains the attributes `playlist_strict_mode` and `playlist_item_limit`. If they are not present, it sets them to `False` and `0`, respectively.

Fixes: https://github.com/alexta69/metube/issues/556