### PR TITLE
Redirect to / when basePath is empty

### DIFF
--- a/ui/src/custom-service-worker.js
+++ b/ui/src/custom-service-worker.js
@@ -29,7 +29,7 @@ self.addEventListener("fetch", (event) => {
               });
             })
           );
-          return Response.redirect(basePath, 303);
+          return Response.redirect(basePath || "/", 303);
         })()
       );
     }


### PR DESCRIPTION
When the path is `/share-target`, `basePath` ends up empty and the `redirect("", 303)` redirects to the JS of the service worker. I got this behaviour on Chrome 135 on MacOS.

<img width="1800" alt="image" src="https://github.com/user-attachments/assets/25aff0c6-8a01-448e-b48b-487a007d521d" />
