### PR TITLE
Add a regex filter to exclude some of the custom directories from the drop-down

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Certain values can be set via environment variables, using the `-e` parameter on
 * __DOWNLOAD_DIRS_INDEXABLE__: if `true`, the download dirs (__DOWNLOAD_DIR__ and __AUDIO_DOWNLOAD_DIR__) are indexable on the webserver. Defaults to `false`.
 * __CUSTOM_DIRS__: whether to enable downloading videos into custom directories within the __DOWNLOAD_DIR__ (or __AUDIO_DOWNLOAD_DIR__). When enabled, a drop-down appears next to the Add button to specify the download directory. Defaults to `true`.
 * __CREATE_CUSTOM_DIRS__: whether to support automatically creating directories within the __DOWNLOAD_DIR__ (or __AUDIO_DOWNLOAD_DIR__) if they do not exist. When enabled, the download directory selector becomes supports free-text input, and the specified directory will be created recursively. Defaults to `true`.
+* __CUSTOM_DIRS_EXCLUDE_REGEX__: regular expression to exclude some custom directories from the drop-down. Empty regex disables exclusion. Defaults to `(^|/)[.@].*$`, which means directories starting with `.` or `@`.
 * __STATE_DIR__: path to where the queue persistence files will be saved. Defaults to `/downloads/.metube` in the docker image, and `.` otherwise.
 * __TEMP_DIR__: path where intermediary download files will be saved. Defaults to `/downloads` in the docker image, and `.` otherwise.
   * Set this to an SSD or RAM filesystem (e.g., `tmpfs`) for better performance

--- a/app/main.py
+++ b/app/main.py
@@ -10,6 +10,7 @@ import socketio
 import logging
 import json
 import pathlib
+import re
 
 from ytdl import DownloadQueueNotifier, DownloadQueue
 from yt_dlp.version import __version__ as yt_dlp_version
@@ -24,6 +25,7 @@ class Config:
         'DOWNLOAD_DIRS_INDEXABLE': 'false',
         'CUSTOM_DIRS': 'true',
         'CREATE_CUSTOM_DIRS': 'true',
+        'CUSTOM_DIRS_EXCLUDE_REGEX': r'(^|/)[.@].*$',
         'DELETE_FILE_ON_TRASHCAN': 'false',
         'STATE_DIR': '.',
         'URL_PREFIX': '',
@@ -214,8 +216,15 @@ def get_custom_dirs():
 
             return s
 
+        # Include only directories which do not match the exclude filter
+        def include_dir(d):
+            if len(config.CUSTOM_DIRS_EXCLUDE_REGEX) == 0:
+                return True
+            else:
+                return re.search(config.CUSTOM_DIRS_EXCLUDE_REGEX, d) is None
+
         # Recursively lists all subdirectories of DOWNLOAD_DIR
-        dirs = list(filter(None, map(convert, path.glob('**'))))
+        dirs = list(filter(include_dir, map(convert, path.glob('**'))))
 
         return dirs
 


### PR DESCRIPTION
Some media-indexers create directories (sometimes a lot of them) for thumbnails etc. next to the files. This adds an option to exclude these directories using a regex, which cleans up the drop-down (in my case from >2k to ~30).

Default is set to exclude directories starting with `.` or `@`, which should be quite reasonable for most users. Setting the option to zero-length string disables the filtering and restores the previous behavior.