### PR TITLE
Fill out main content, align footer with bottom

### DIFF
--- a/ui/src/app/app.component.sass
+++ b/ui/src/app/app.component.sass
@@ -93,22 +93,22 @@ td
 .d-flex.my-3
   margin-top: 1rem
   margin-bottom: 1rem
- 
+
 .modal.fade.show
   background-color: rgba(0, 0, 0, 0.5)
 
 .modal-header
   border-bottom: 1px solid #eee
-  
+
 .modal-body
   textarea.form-control
     resize: vertical
- 
+
 .add-url
   display: inline-flex
   align-items: center
   justify-content: center
- 
+
   .spinner-border
     margin-right: 0.5rem
 
@@ -126,6 +126,14 @@ td
                 white-space: nowrap
                 overflow: visible
                 text-overflow: ellipsis
+
+app-root
+  display: flex
+  flex-direction: column
+  min-height: 100vh
+
+main
+  flex-grow: 1
 
 .footer
   width: 100%


### PR DESCRIPTION
Make the app root fill at least the full height of the viewport, and
make the main content grow to fill the empty space - aligning the footer
with the bottom of the page at all times.
