### PR TITLE
Fix host component style

### DIFF
--- a/ui/src/app/app.component.sass
+++ b/ui/src/app/app.component.sass
@@ -127,7 +127,7 @@ td
                 overflow: visible
                 text-overflow: ellipsis
 
-app-root
+:host
   display: flex
   flex-direction: column
   min-height: 100vh


### PR DESCRIPTION
Fix the SASS rule for the app root component not being applied as it was
written for the app root element, not the host scope.

Fixes: d03c710636ccd6db51da1661ddf37ac951577a64
