### PR TITLE
chore(docker): remove deno

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY pyproject.toml uv.lock docker-entrypoint.sh ./
 # Install dependencies
 RUN sed -i 's/\r$//g' docker-entrypoint.sh && \
     chmod +x docker-entrypoint.sh && \
-    apk add --update ffmpeg aria2 coreutils shadow su-exec curl tini deno && \
+    apk add --update ffmpeg aria2 coreutils shadow su-exec curl tini && \
     apk add --update --virtual .build-deps gcc g++ musl-dev uv && \
     UV_PROJECT_ENVIRONMENT=/usr/local uv sync --frozen --no-dev --compile-bytecode && \
     apk del .build-deps && \


### PR DESCRIPTION
Motivation : 

Removing deno save nearly 100mb on docker image.
BE is using python , FE is using Angular , i don't see a reason to have deno . 

with deno : 
<img width="521" height="36" alt="Capture d’écran 2025-12-13 à 13 51 33" src="https://github.com/user-attachments/assets/0a71e07e-caaa-4956-b30e-126634ee8766" />

without deno : 
<img width="532" height="35" alt="Capture d’écran 2025-12-13 à 14 05 30" src="https://github.com/user-attachments/assets/cdc6985a-589b-40c7-a356-dbc8c556b8af" />
