### PR TITLE
Suppress download progress update in logs

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -140,7 +140,7 @@ class Notifier(DownloadQueueNotifier):
         await sio.emit('added', serializer.encode(dl))
 
     async def updated(self, dl):
-        log.info(f"Notifier: Download updated - {dl.title}")
+        log.debug(f"Notifier: Download updated - {dl.title}")
         await sio.emit('updated', serializer.encode(dl))
 
     async def completed(self, dl):

--- a/app/ytdl.py
+++ b/app/ytdl.py
@@ -187,7 +187,7 @@ class Download:
                     self.info.percent = status['downloaded_bytes'] / total * 100
             self.info.speed = status.get('speed')
             self.info.eta = status.get('eta')
-            log.info(f"Updating status for {self.info.title}: {status}")
+            log.debug(f"Updating status for {self.info.title}: {status}")
             await self.notifier.updated(self.info)
 
 class PersistentQueue:


### PR DESCRIPTION
Thanks for pulling my previous commit.

This PR aimed to reduce logs when downloading video by sending status update log to debug so it no longer spam the hell out of syslog/journal in regular use. For large enough video these can account for tens of thousands lines of update. (BLAST Rivals Hong Kong Grand Final, 27GB, generated ~75K lines)

<img width="3479" height="1544" alt="image" src="https://github.com/user-attachments/assets/54a6cdad-29d1-4321-b788-a4a546fbd491" />
