### PR TITLE
fix completed result tooltip

### DIFF
--- a/ui/src/app/app.html
+++ b/ui/src/app/app.html
@@ -395,7 +395,7 @@
                   <fa-icon [icon]="faTimesCircle" class="text-danger" />
                 }
               </div>
-              <span ngbTooltip="{{download.value.msg}} | {{download.value.error}}">@if (!!download.value.filename) {
+              <span ngbTooltip="{{buildResultItemTooltip(download.value)}}">@if (!!download.value.filename) {
                 <a href="{{buildDownloadLink(download.value)}}" target="_blank">{{ download.value.title }}</a>
               } @else {
                 {{download.value.title}}

--- a/ui/src/app/app.ts
+++ b/ui/src/app/app.ts
@@ -367,6 +367,16 @@ export class App implements AfterViewInit, OnInit {
     return baseDir + encodeURIComponent(download.filename);
   }
 
+  buildResultItemTooltip(download: Download) {
+    const parts = [];
+    if (download.msg) {
+      parts.push(download.msg);
+    }
+    if (download.error) {
+      parts.push(download.error);
+    }
+    return parts.join(' | ');
+  }
 
   isNumber(event: KeyboardEvent) {
     const charCode = +event.code || event.keyCode;


### PR DESCRIPTION
**Before the fix:**
![GIF 2025-12-27 10-53-33](https://github.com/user-attachments/assets/f6b696ce-3bc7-428f-8106-60d734a4116e)
Items in the completed task list always had a tooltip, even when there was no `msg` or `error`.

**After the fix:**
The tooltip is shown only when there is a `msg` or an `error`.
