### PR TITLE
Improves logging, helpful when debugging yt-dlp options

### DIFF
--- a/app/ytdl.py
+++ b/app/ytdl.py
@@ -83,6 +83,7 @@ class Download:
     def _download(self):
         log.info(f"Starting download for: {self.info.title} ({self.info.url})")
         try:
+            debug_logging = logging.getLogger().isEnabledFor(logging.DEBUG)
             def put_status(st):
                 self.status_queue.put({k: v for k, v in st.items() if k in (
                     'tmpfilename',
@@ -105,7 +106,8 @@ class Download:
                     self.status_queue.put({'status': 'finished', 'filename': filename})
 
             ret = yt_dlp.YoutubeDL(params={
-                'quiet': True,
+                'quiet': not debug_logging,
+                'verbose': debug_logging,
                 'no_color': True,
                 'paths': {"home": self.download_dir, "temp": self.temp_dir},
                 'outtmpl': { "default": self.output_template, "chapter": self.output_template_chapter },
@@ -314,8 +316,10 @@ class DownloadQueue:
                 asyncio.create_task(self.notifier.completed(download.info))
 
     def __extract_info(self, url, playlist_strict_mode):
+        debug_logging = logging.getLogger().isEnabledFor(logging.DEBUG)
         return yt_dlp.YoutubeDL(params={
-            'quiet': True,
+            'quiet': not debug_logging,
+            'verbose': debug_logging,
             'no_color': True,
             'extract_flat': True,
             'ignore_no_formats_error': True,


### PR DESCRIPTION
I started messing with and yt-dlp options and nothing was working. I set logging to DEBUG in launch.json but log.info() in the main.py does not print anything.
Eventually I figured it all out. This is a PR to help the next person.

## Summary
Improves logging configuration to prevent dropped early log messages and makes yt-dlp verbosity respect the application's log level.

## Changes

### Early Logging Initialization
- Moved `parseLogLevel()` function to the top of `main.py` for early access
- Configure logging with `basicConfig()` before `Config()` instantiation to capture early startup messages
- Added safety check to avoid overwriting existing handlers when MeTube is embedded in other applications

### Synchronized Log Level Management
- Re-apply log level after `Config()` loads to respect config file settings that may override environment variables
- Ensures Config remains the single source of truth for LOGLEVEL throughout the application

### yt-dlp Verbosity Control
- Made yt-dlp respect DEBUG log level by dynamically checking if DEBUG logging is enabled
- When DEBUG is active, yt-dlp runs with `quiet=False` and `verbose=True`
- Applied to both download operations (`_download()`) and info extraction (`__extract_info()`)
- Production behavior unchanged: yt-dlp remains quiet at INFO and higher log levels

## Benefits
- **No more dropped messages**: Early configuration ensures startup logs are captured
- **Better debugging**: yt-dlp verbose output available when `LOGLEVEL=DEBUG`
- **Cleaner production logs**: yt-dlp remains quiet at standard log levels
- **Consistent behavior**: Log level changes are respected throughout the application lifecycle

## Testing
Tested with:
- `LOGLEVEL=DEBUG` - confirms yt-dlp verbose output appears
- `LOGLEVEL=INFO` - confirms yt-dlp remains quiet (current behavior)
- Various log level configurations to ensure proper fallback handling