### PR TITLE
Refactor output template field substitution logic

### DIFF
--- a/app/ytdl.py
+++ b/app/ytdl.py
@@ -491,7 +491,7 @@ class DownloadQueue:
                 output = self.config.OUTPUT_TEMPLATE_PLAYLIST
             for property, value in entry.items():
                 if property.startswith("playlist"):
-                    output = output.replace(f"%({property})s", str(value))
+                    output = _outtmpl_substitute_field(output, property, value)
         if entry is not None and entry.get('channel_index') is not None:
             if len(self.config.OUTPUT_TEMPLATE_CHANNEL):
                 output = self.config.OUTPUT_TEMPLATE_CHANNEL


### PR DESCRIPTION

### Description:
This pull request introduces a refactor to the ytdl.py file, replacing manual `.replace("%(playlist_*)s", ...)` calls with a regex-based substitution approach. The implementation leverages `yt_dlp.utils.STR_FORMAT_RE_TMPL` to handle `%`-style placeholders dynamically, improving maintainability and reducing hardcoded logic.

#### Key Changes:
1. Added `_outtmpl_substitute_field` function:
   - Handles regex-based substitution for playlist-related fields.
   - Supports placeholders like `%(...)s`, `%(...)02d`, and other formats.
2. Updated the logic to align with Python's `%` operator behavior for string formatting.
3. Improved compatibility with complex output templates, including:
   - `%(playlist_title)s/%(playlist_index)02d. %(title)s.%(ext)s`

#### Examples:
- Input Template: `%(playlist_title)s/%(playlist_index)02d. %(title)s.%(ext)s`
- Output Example: `My Playlist/01. Example Video.mp4`
