### PR TITLE
add initial docker-compose configuration for metube service

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,9 @@
+services:
+  metube:
+    image: ghcr.io/alexta69/metube
+    container_name: metube
+    restart: unless-stopped
+    ports:
+      - "8081:8081"
+    volumes:
+      - /path/to/downloads:/downloads


### PR DESCRIPTION
The docker compose file was missing which cause the crashing of "docker composer up"  command to run