### PR TITLE
Cancel playlist adding mid-operation

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -322,6 +322,11 @@ async def start(request):
     status = await dqueue.start_pending(ids)
     return web.Response(text=serializer.encode(status))
 
+@routes.post(config.URL_PREFIX + 'cancel-add')
+async def cancel_add(request):
+    dqueue.cancel_add()
+    return web.Response(text=serializer.encode({'status': 'ok'}), content_type='application/json')
+
 @routes.get(config.URL_PREFIX + 'history')
 async def history(request):
     history = { 'done': [], 'queue': [], 'pending': []}
@@ -433,6 +438,7 @@ async def add_cors(request):
     return web.Response(text=serializer.encode({"status": "ok"}))
 
 app.router.add_route('OPTIONS', config.URL_PREFIX + 'add', add_cors)
+app.router.add_route('OPTIONS', config.URL_PREFIX + 'cancel-add', add_cors)
 
 async def on_prepare(request, response):
     if 'Origin' in request.headers:

--- a/ui/src/app/app.html
+++ b/ui/src/app/app.html
@@ -98,15 +98,17 @@
               name="addUrl"
               [(ngModel)]="addUrl"
               [disabled]="addInProgress || downloads.loading">
-            <button class="btn btn-primary btn-lg px-4"
-              type="submit"
-              (click)="addDownload()"
-              [disabled]="addInProgress || downloads.loading">
-              @if (addInProgress) {
-                <span class="spinner-border spinner-border-sm" role="status" id="add-spinner"></span>
-              }
-              {{ addInProgress ? "Adding..." : "Download" }}
-            </button>
+            @if (addInProgress) {
+              <button class="btn btn-danger btn-lg px-3" type="button" (click)="cancelAdding()">
+                <fa-icon [icon]="faTimesCircle" class="me-1" /> Cancel
+              </button>
+            } @else {
+              <button class="btn btn-primary btn-lg px-4" type="submit"
+                (click)="addDownload()"
+                [disabled]="downloads.loading">
+                Download
+              </button>
+            }
           </div>
         </div>
       </div>

--- a/ui/src/app/app.ts
+++ b/ui/src/app/app.ts
@@ -427,6 +427,13 @@ export class App implements AfterViewInit, OnInit {
     });
   }
 
+  cancelAdding() {
+    this.downloads.cancelAdd().subscribe({
+      next: () => { this.addInProgress = false; },
+      error: () => { this.addInProgress = false; }
+    });
+  }
+
   downloadItemByKey(id: string) {
     this.downloads.startById([id]).subscribe();
   }

--- a/ui/src/app/services/downloads.service.ts
+++ b/ui/src/app/services/downloads.service.ts
@@ -208,6 +208,10 @@ export class DownloadsService {
   public exportQueueUrls(): string[] {
     return Array.from(this.queue.values()).map(download => download.url);
   }
-  
-  
+
+  public cancelAdd() {
+    return this.http.post<any>('cancel-add', {}).pipe(
+      catchError(this.handleHTTPError)
+    );
+  }
 }


### PR DESCRIPTION
Addresses #840.

Adds a cancel button that appears while a playlist is being added. Clicking it sets an abort flag that's checked between entries in the playlist loop, so already-queued items stay and the rest are skipped.

**What changed:**
- `ytdl.py`: `_add_canceled` flag, `cancel_add()` method, flag check at top of entry loop, reset on fresh `add()` calls
- `main.py`: `POST /cancel-add` route + CORS
- `downloads.service.ts`: `cancelAdd()` service method
- `app.ts`: `cancelAdding()` method
- `app.html`: download button swaps to red Cancel button when `addInProgress`

Kept the backend changes minimal — just a boolean flag and one route.