### PR TITLE
Add cookie file upload for authenticated downloads

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -327,6 +327,43 @@ async def start(request):
     status = await dqueue.start_pending(ids)
     return web.Response(text=serializer.encode(status))
 
+
+COOKIES_PATH = os.path.join(config.STATE_DIR, 'cookies.txt')
+
+@routes.post(config.URL_PREFIX + 'upload-cookies')
+async def upload_cookies(request):
+    reader = await request.multipart()
+    field = await reader.next()
+    if field is None or field.name != 'cookies':
+        return web.Response(status=400, text=serializer.encode({'status': 'error', 'msg': 'No cookies file provided'}))
+    size = 0
+    with open(COOKIES_PATH, 'wb') as f:
+        while True:
+            chunk = await field.read_chunk()
+            if not chunk:
+                break
+            size += len(chunk)
+            if size > 1_000_000:  # 1MB limit
+                os.remove(COOKIES_PATH)
+                return web.Response(status=400, text=serializer.encode({'status': 'error', 'msg': 'Cookie file too large (max 1MB)'}))
+            f.write(chunk)
+    config.YTDL_OPTIONS['cookiefile'] = COOKIES_PATH
+    log.info(f'Cookies file uploaded ({size} bytes)')
+    return web.Response(text=serializer.encode({'status': 'ok', 'msg': f'Cookies uploaded ({size} bytes)'}))
+
+@routes.post(config.URL_PREFIX + 'delete-cookies')
+async def delete_cookies(request):
+    if os.path.exists(COOKIES_PATH):
+        os.remove(COOKIES_PATH)
+    config.YTDL_OPTIONS.pop('cookiefile', None)
+    log.info('Cookies file deleted')
+    return web.Response(text=serializer.encode({'status': 'ok'}))
+
+@routes.get(config.URL_PREFIX + 'cookie-status')
+async def cookie_status(request):
+    exists = os.path.exists(COOKIES_PATH)
+    return web.Response(text=serializer.encode({'status': 'ok', 'has_cookies': exists}))
+
 @routes.get(config.URL_PREFIX + 'history')
 async def history(request):
     history = { 'done': [], 'queue': [], 'pending': []}
@@ -439,6 +476,8 @@ async def add_cors(request):
 
 app.router.add_route('OPTIONS', config.URL_PREFIX + 'add', add_cors)
 app.router.add_route('OPTIONS', config.URL_PREFIX + 'cancel-add', add_cors)
+app.router.add_route('OPTIONS', config.URL_PREFIX + 'upload-cookies', add_cors)
+app.router.add_route('OPTIONS', config.URL_PREFIX + 'delete-cookies', add_cors)
 
 async def on_prepare(request, response):
     if 'Origin' in request.headers:
@@ -465,6 +504,12 @@ def isAccessLogEnabled():
 if __name__ == '__main__':
     logging.getLogger().setLevel(parseLogLevel(config.LOGLEVEL) or logging.INFO)
     log.info(f"Listening on {config.HOST}:{config.PORT}")
+
+
+    # Auto-detect cookie file on startup
+    if os.path.exists(COOKIES_PATH):
+        config.YTDL_OPTIONS['cookiefile'] = COOKIES_PATH
+        log.info(f'Cookie file detected at {COOKIES_PATH}')
 
     if config.HTTPS:
         ssl_context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)

--- a/ui/src/app/app.html
+++ b/ui/src/app/app.html
@@ -212,6 +212,24 @@
                   </div>
                 </div>
                 <div class="col-md-6">
+                  <div class="d-flex align-items-center mt-2">
+                    <label class="btn btn-sm btn-outline-secondary me-2 mb-0" for="cookie-upload"
+                      ngbTooltip="Upload a cookies.txt file for authenticated downloads">
+                      <fa-icon [icon]="faUpload" class="me-1" />Cookies
+                    </label>
+                    <input type="file" id="cookie-upload" class="d-none" accept=".txt"
+                      (change)="onCookieFileSelect($event)"
+                      [disabled]="cookieUploadInProgress || addInProgress">
+                    @if (hasCookies) {
+                      <span class="badge bg-success me-2">Active</span>
+                      <button type="button" class="btn btn-sm btn-outline-danger"
+                        (click)="deleteCookies()" ngbTooltip="Remove uploaded cookies">
+                        <fa-icon [icon]="faTrashAlt" />
+                      </button>
+                    }
+                  </div>
+                </div>
+                <div class="col-md-6">
                   <div class="input-group">
                     <span class="input-group-text">Items Limit</span>
                     <input type="number"

--- a/ui/src/app/app.ts
+++ b/ui/src/app/app.ts
@@ -6,7 +6,7 @@ import { FormsModule } from '@angular/forms';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { NgSelectModule } from '@ng-select/ng-select';  
-import { faTrashAlt, faCheckCircle, faTimesCircle, faRedoAlt, faSun, faMoon, faCheck, faCircleHalfStroke, faDownload, faExternalLinkAlt, faFileImport, faFileExport, faCopy, faClock, faTachometerAlt, faSortAmountDown, faSortAmountUp, faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { faTrashAlt, faCheckCircle, faTimesCircle, faRedoAlt, faSun, faMoon, faCheck, faCircleHalfStroke, faDownload, faExternalLinkAlt, faFileImport, faFileExport, faCopy, faClock, faTachometerAlt, faSortAmountDown, faSortAmountUp, faChevronRight, faUpload } from '@fortawesome/free-solid-svg-icons';
 import { faGithub } from '@fortawesome/free-brands-svg-icons';
 import { CookieService } from 'ngx-cookie-service';
 import { DownloadsService } from './services/downloads.service';
@@ -54,6 +54,8 @@ export class App implements AfterViewInit, OnInit {
   subtitleMode: string;
   addInProgress = false;
   cancelRequested = false;
+  hasCookies = false;
+  cookieUploadInProgress = false;
   themes: Theme[] = Themes;
   activeTheme: Theme | undefined;
   customDirs$!: Observable<string[]>;
@@ -108,6 +110,7 @@ export class App implements AfterViewInit, OnInit {
   faSortAmountDown = faSortAmountDown;
   faSortAmountUp = faSortAmountUp;
   faChevronRight = faChevronRight;
+  faUpload = faUpload;
   subtitleFormats = [
     { id: 'srt', text: 'SRT' },
     { id: 'txt', text: 'TXT (Text only)' },
@@ -205,6 +208,9 @@ export class App implements AfterViewInit, OnInit {
   }
 
   ngOnInit() {
+    this.downloads.getCookieStatus().subscribe(data => {
+      this.hasCookies = data?.has_cookies || false;
+    });
     this.getConfiguration();
     this.getYtdlOptionsUpdateTime();
     this.customDirs$ = this.getMatchingCustomDir();
@@ -780,6 +786,30 @@ export class App implements AfterViewInit, OnInit {
 
   isErrorExpanded(id: string): boolean {
     return this.expandedErrors.has(id);
+  }
+
+  onCookieFileSelect(event: Event) {
+    const input = event.target as HTMLInputElement;
+    if (!input.files?.length) return;
+    this.cookieUploadInProgress = true;
+    this.downloads.uploadCookies(input.files[0]).subscribe({
+      next: () => {
+        this.hasCookies = true;
+        this.cookieUploadInProgress = false;
+        input.value = '';
+      },
+      error: () => {
+        this.cookieUploadInProgress = false;
+        input.value = '';
+      }
+    });
+  }
+
+  deleteCookies() {
+    this.downloads.deleteCookies().subscribe({
+      next: () => { this.hasCookies = false; },
+      error: () => {}
+    });
   }
 
   private updateMetrics() {

--- a/ui/src/app/services/downloads.service.ts
+++ b/ui/src/app/services/downloads.service.ts
@@ -213,4 +213,24 @@ export class DownloadsService {
       catchError(this.handleHTTPError)
     );
   }
+
+  uploadCookies(file: File) {
+    const formData = new FormData();
+    formData.append('cookies', file);
+    return this.http.post<any>('upload-cookies', formData).pipe(
+      catchError(this.handleHTTPError)
+    );
+  }
+
+  deleteCookies() {
+    return this.http.post<any>('delete-cookies', {}).pipe(
+      catchError(this.handleHTTPError)
+    );
+  }
+
+  getCookieStatus() {
+    return this.http.get<any>('cookie-status').pipe(
+      catchError(this.handleHTTPError)
+    );
+  }
 }


### PR DESCRIPTION
## Summary

Adds the ability to upload a `cookies.txt` file through the MeTube UI, enabling yt-dlp to download age-restricted, member-only, or region-locked content.

- Upload, delete, and status check endpoints in `main.py`
- Cookie file stored at `config.STATE_DIR/cookies.txt` (inside the `/downloads/.metube` volume)
- Auto-detection on startup: if the cookie file exists, `YTDL_OPTIONS['cookiefile']` is re-populated so cookies survive container restarts
- Simple UI: upload button, "Active" badge, and delete button in the download options area
- 1MB file size limit on uploads

## Changes

- `app/main.py` - Three new endpoints (`upload-cookies`, `delete-cookies`, `cookie-status`), CORS routes, and startup auto-detect
- `ui/src/app/app.ts` - Cookie state, upload handler, delete handler
- `ui/src/app/app.html` - Upload button and status badge UI
- `ui/src/app/services/downloads.service.ts` - Three new API methods

## Test plan

- [x] Upload a cookies.txt file, verify "Active" badge appears
- [x] Download an age-restricted video, verify it succeeds
- [x] Delete cookies via UI, verify badge disappears
- [x] Restart the container, verify "Active" badge persists and logs show `Cookie file detected at /downloads/.metube/cookies.txt`
- [x] Verify `pnpm run build` passes clean

A human has tested this feature and approved this message ;)