### PR TITLE
Add Downloaded timestamp column to completed downloads list

### DIFF
--- a/ui/src/app/app.html
+++ b/ui/src/app/app.html
@@ -490,6 +490,7 @@
           </th>
           <th scope="col">Video</th>
           <th scope="col">File Size</th>
+          <th scope="col">Downloaded</th>
           <th scope="col" style="width: 8rem;"></th>
         </tr>
       </thead>
@@ -556,6 +557,11 @@
                 <span>{{ entry[1].size | fileSize }}</span>
               }
             </td>
+            <td class="text-nowrap">
+              @if (entry[1].timestamp) {
+                <span>{{ entry[1].timestamp / 1000000 | date:'yyyy-MM-dd HH:mm' }}</span>
+              }
+            </td>
             <td>
               <div class="d-flex">
                 @if (entry[1].status === 'error') {
@@ -585,6 +591,7 @@
             <span>{{ chapterFile.size | fileSize }}</span>
             }
           </td>
+          <td></td>
           <td>
             <div class="d-flex">
               <a href="{{buildChapterDownloadLink(entry[1], chapterFile.filename)}}" download

--- a/ui/src/app/app.ts
+++ b/ui/src/app/app.ts
@@ -1,4 +1,4 @@
-import { AsyncPipe, KeyValuePipe } from '@angular/common';
+import { AsyncPipe, DatePipe, KeyValuePipe } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
 import { AfterViewInit, Component, ElementRef, viewChild, inject, OnInit } from '@angular/core';
 import { Observable, map, distinctUntilChanged } from 'rxjs';
@@ -21,6 +21,7 @@ import { MasterCheckboxComponent , SlaveCheckboxComponent} from './components/';
         FormsModule,
         KeyValuePipe,
         AsyncPipe,
+        DatePipe,
         FontAwesomeModule,
         NgbModule,
         NgSelectModule,

--- a/ui/src/app/interfaces/download.ts
+++ b/ui/src/app/interfaces/download.ts
@@ -20,6 +20,7 @@ export interface Download {
   eta: number;
   filename: string;
   checked: boolean;
+  timestamp?: number;
   size?: number;
   error?: string;
   deleting?: boolean;


### PR DESCRIPTION
## Summary
- Add a "Downloaded" column to the completed downloads table showing when each download finished
- The backend already stores a nanosecond timestamp on `DownloadInfo`; this wires it up to the frontend using Angular's `DatePipe`
- Format: `yyyy-MM-dd HH:mm`

## Changes
- `ui/src/app/interfaces/download.ts` — added `timestamp` field to `Download` interface
- `ui/src/app/app.ts` — imported `DatePipe`
- `ui/src/app/app.html` — added "Downloaded" column header and timestamp display

## Test plan
- [ ] Add a download and verify the timestamp appears in the "Downloaded" column after completion
- [ ] Verify older downloads without a timestamp show a blank cell
- [ ] Verify chapter file rows remain properly aligned