### PR TITLE
Fix permissive CORS policy that allows cross-origin attacks

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -60,6 +60,7 @@ class Config:
         'YTDL_OPTIONS_PRESETS': '{}',
         'YTDL_OPTIONS_PRESETS_FILE': '',
         'ALLOW_YTDL_OPTIONS_OVERRIDES': 'false',
+        'CORS_ALLOWED_ORIGINS': '',
         'ROBOTS_TXT': '',
         'HOST': '0.0.0.0',
         'PORT': '8081',
@@ -223,7 +224,8 @@ class ObjectSerializer(json.JSONEncoder):
 
 serializer = ObjectSerializer()
 app = web.Application()
-sio = socketio.AsyncServer(cors_allowed_origins='*')
+_cors_origins = [o.strip() for o in config.CORS_ALLOWED_ORIGINS.split(',') if o.strip()] if config.CORS_ALLOWED_ORIGINS else []
+sio = socketio.AsyncServer(cors_allowed_origins=_cors_origins if _cors_origins else [])
 sio.attach(app, socketio_path=config.URL_PREFIX + 'socket.io')
 routes = web.RouteTableDef()
 VALID_SUBTITLE_FORMATS = {'srt', 'txt', 'vtt', 'ttml', 'sbv', 'scc', 'dfxp'}
@@ -912,8 +914,9 @@ app.router.add_route('OPTIONS', config.URL_PREFIX + 'upload-cookies', add_cors)
 app.router.add_route('OPTIONS', config.URL_PREFIX + 'delete-cookies', add_cors)
 
 async def on_prepare(request, response):
-    if 'Origin' in request.headers:
-        response.headers['Access-Control-Allow-Origin'] = request.headers['Origin']
+    origin = request.headers.get('Origin')
+    if origin and _cors_origins and origin in _cors_origins:
+        response.headers['Access-Control-Allow-Origin'] = origin
         response.headers['Access-Control-Allow-Headers'] = 'Content-Type'
 
 app.on_response_prepare.append(on_prepare)


### PR DESCRIPTION
## Summary

- The `on_prepare` handler unconditionally reflects the `Origin` request header into `Access-Control-Allow-Origin`, and Socket.IO is configured with `cors_allowed_origins='*'`
- This allows **any website** to make cross-origin requests to all API endpoints without authentication
- An attacker can force the server to download arbitrary content (`POST /add`), overwrite cookies (`POST /upload-cookies`), delete downloads (`POST /delete`), and create subscriptions (`POST /subscribe`) — all from a malicious webpage the victim visits

## Fix

- Replace blanket origin reflection with an explicit allowlist via the `CORS_ALLOWED_ORIGINS` environment variable
- When unset, cross-origin requests are denied by default
- Users who need cross-origin access (browser extensions, external clients) can set `CORS_ALLOWED_ORIGINS` to a comma-separated list of trusted origins

## Reproduction

1. Run MeTube: `docker run -d -p 8081:8081 alexta69/metube`
2. Open this HTML file in a browser:

```html
<script>
fetch('http://localhost:8081/add', {
    method: 'POST',
    headers: {'Content-Type': 'application/json'},
    body: JSON.stringify({
        url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
        quality: 'best',
        download_type: 'video',
        format: 'any',
        codec: 'auto'
    })
}).then(r => r.text()).then(console.log);
</script>
```

3. Observe the download appears in MeTube UI — the cross-origin request succeeds

## Test plan

- [ ] Verify MeTube UI still works normally (same-origin, no CORS needed)
- [ ] Verify cross-origin requests are blocked when `CORS_ALLOWED_ORIGINS` is unset
- [ ] Verify cross-origin requests work when `CORS_ALLOWED_ORIGINS` is set to the requesting origin
- [ ] Verify Socket.IO connections respect the same allowlist