### PR TITLE
Block dangerous yt-dlp options in ytdl_options_overrides

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -234,6 +234,12 @@ VALID_VIDEO_CODECS = {'auto', 'h264', 'h265', 'av1', 'vp9'}
 VALID_VIDEO_FORMATS = {'any', 'mp4', 'ios'}
 VALID_AUDIO_FORMATS = {'m4a', 'mp3', 'opus', 'wav', 'flac'}
 VALID_THUMBNAIL_FORMATS = {'jpg'}
+_BLOCKED_YTDL_OVERRIDE_KEYS = frozenset({
+    'exec_cmd', 'exec', 'postprocessors', 'post_hooks',
+    'external_downloader', 'external_downloader_args',
+    'cookiefile', 'cookiesfrombrowser',
+})
+
 def _parse_ytdl_options_overrides(value, *, enabled: bool) -> dict:
     if value is None or value == '':
         return {}
@@ -249,6 +255,10 @@ def _parse_ytdl_options_overrides(value, *, enabled: bool) -> dict:
 
     if value and not enabled:
         raise web.HTTPBadRequest(reason='ytdl_options_overrides are disabled')
+
+    blocked = set(value.keys()) & _BLOCKED_YTDL_OVERRIDE_KEYS
+    if blocked:
+        raise web.HTTPBadRequest(reason=f'ytdl_options_overrides contains blocked keys: {sorted(blocked)}')
 
     return value
 


### PR DESCRIPTION
## Summary

- When `ALLOW_YTDL_OPTIONS_OVERRIDES=true`, the `/add` endpoint accepts arbitrary yt-dlp options as JSON and passes them directly to `yt_dlp.YoutubeDL()` without restriction
- An attacker can inject a yt-dlp `Exec` postprocessor that executes arbitrary OS commands on the server after a download completes
- Combined with the permissive CORS policy (#949), this is exploitable from any website the victim visits

## Fix

Add a blocklist of dangerous yt-dlp option keys that are rejected when present in overrides:

- `exec_cmd`, `exec` — execute shell commands after download
- `postprocessors`, `post_hooks` — inject arbitrary postprocessors (including `Exec`)
- `external_downloader`, `external_downloader_args` — specify custom download executables
- `cookiefile`, `cookiesfrombrowser` — read arbitrary cookie files from the filesystem

## Reproduction

1. Run MeTube with overrides enabled:
   ```
   docker run -d -p 8081:8081 -e ALLOW_YTDL_OPTIONS_OVERRIDES=true alexta69/metube
   ```

2. Send a request with a malicious postprocessor:
   ```bash
   curl -X POST http://localhost:8081/add \
     -H 'Content-Type: application/json' \
     -d '{
       "url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
       "quality": "128",
       "download_type": "audio",
       "format": "mp3",
       "codec": "auto",
       "ytdl_options_overrides": {
         "postprocessors": [{"key": "Exec", "exec_cmd": "touch /tmp/rce-proof"}]
       }
     }'
   ```

3. After the download completes, verify:
   ```
   docker exec <container> ls -la /tmp/rce-proof
   ```

## Test plan

- [ ] Verify `postprocessors` in overrides is rejected with 400
- [ ] Verify `exec_cmd` in overrides is rejected with 400
- [ ] Verify safe overrides (e.g. `{"format": "bestaudio"}`) still work
- [ ] Verify server-side `YTDL_OPTIONS` and `YTDL_OPTIONS_PRESETS` are not affected by the blocklist