### PR TITLE
Ability to auto download live streams with subscription

### DIFF
--- a/app/subscriptions.py
+++ b/app/subscriptions.py
@@ -483,6 +483,8 @@ class SubscriptionManager:
             seen_entries = [ent for ent in entries if _is_media_entry(ent)]
             all_ids: list[str] = []
             for ent in seen_entries:
+                if ent.get("live_status") == "is_upcoming":
+                    continue  # Don't mark scheduled streams as seen; queue them when they go live
                 eid = _entry_id(ent)
                 if eid:
                     all_ids.append(eid)
@@ -662,7 +664,9 @@ class SubscriptionManager:
         new_ids: list[str] = []
         for ent in entries:
             eid = _entry_id(ent)
-            if not eid or eid in seen:
+            if not eid:
+                continue
+            if eid in seen and ent.get("live_status") != "is_live":
                 continue
             new_entries.append(ent)
             new_ids.append(eid)


### PR DESCRIPTION
If there is an upcoming/ongoing live stream, it is being marked as seen so it will be never added to the queue.

The https://www.youtube.com/@somechannel fetches the videos only. 
But if I add the https://www.youtube.com/@somechannel/streams as a separate subscription, it could download the live streams automatically. Current behaviour blocks this feature.

If it fetches every hour like below, the `live_from_start` will download from the beginning. 
```
    environment:
      - SUBSCRIPTION_DEFAULT_CHECK_INTERVAL=60 
      - YTDL_OPTIONS={"wait_for_video":[1,30],"live_from_start":true}
```