### PR TITLE
feat(ui): add Web Share button to completed downloads (iOS Save to Photos)

### DIFF
--- a/ui/src/app/app.html
+++ b/ui/src/app/app.html
@@ -854,6 +854,9 @@
                 @if (entry[1].filename) {
                   <a href="{{buildDownloadLink(entry[1])}}" download class="btn btn-link" [attr.aria-label]="'Download result file for ' + entry[1].title"><fa-icon [icon]="faDownload" /></a>
                 }
+                @if (entry[1].filename && canShareDownloads()) {
+                  <button type="button" class="btn btn-link" [attr.aria-label]="'Share result file for ' + entry[1].title" (click)="shareDownload(entry[1])" ngbTooltip="Share — on iOS opens the share sheet (Save to Photos, Files, AirDrop…)"><fa-icon [icon]="faShareNodes" /></button>
+                }
                 <a href="{{entry[1].url}}" target="_blank" class="btn btn-link" [attr.aria-label]="'Open source URL for ' + entry[1].title"><fa-icon [icon]="faExternalLinkAlt" /></a>
                 <button type="button" class="btn btn-link" [attr.aria-label]="'Delete completed item ' + entry[1].title" (click)="delDownload('done', entry[0])"><fa-icon [icon]="faTrashAlt" /></button>
               </div>

--- a/ui/src/app/app.html
+++ b/ui/src/app/app.html
@@ -855,7 +855,7 @@
                   <a href="{{buildDownloadLink(entry[1])}}" download class="btn btn-link" [attr.aria-label]="'Download result file for ' + entry[1].title"><fa-icon [icon]="faDownload" /></a>
                 }
                 @if (entry[1].filename && canShareDownloads()) {
-                  <button type="button" class="btn btn-link" [attr.aria-label]="'Share result file for ' + entry[1].title" (click)="shareDownload(entry[1])" ngbTooltip="Share — on iOS opens the share sheet (Save to Photos, Files, AirDrop…)"><fa-icon [icon]="faShareNodes" /></button>
+                  <button type="button" class="btn btn-link" [attr.aria-label]="'Share result file for ' + entry[1].title" (click)="shareDownload(entry[1])"><fa-icon [icon]="faShareNodes" /></button>
                 }
                 <a href="{{entry[1].url}}" target="_blank" class="btn btn-link" [attr.aria-label]="'Open source URL for ' + entry[1].title"><fa-icon [icon]="faExternalLinkAlt" /></a>
                 <button type="button" class="btn btn-link" [attr.aria-label]="'Delete completed item ' + entry[1].title" (click)="delDownload('done', entry[0])"><fa-icon [icon]="faTrashAlt" /></button>

--- a/ui/src/app/app.ts
+++ b/ui/src/app/app.ts
@@ -1203,9 +1203,27 @@ export class App implements AfterViewInit, OnInit, OnDestroy {
       && typeof navigator.canShare === 'function';
   }
 
+  // Conservative warning threshold for the share sheet — iOS' actual
+  // refusal limit varies between ~50 MB (older versions) and ~150 MB
+  // (recent ones). 80 MB warns the user before the time-wasting fetch+
+  // copy of a too-large file that the platform will then reject.
+  private static readonly SHARE_SIZE_WARN_BYTES = 80 * 1024 * 1024;
+
   async shareDownload(download: Download): Promise<void> {
     if (!this.canShareDownloads()) {
       return;
+    }
+    // Pre-flight size check: warn the user about the iOS share-sheet
+    // soft-fail on large files, before we spend time fetching the whole
+    // file into memory only to have navigator.canShare reject it.
+    if (download.size && download.size > App.SHARE_SIZE_WARN_BYTES) {
+      const sizeMb = Math.round(download.size / 1024 / 1024);
+      const proceed = window.confirm(
+        `This file is ${sizeMb} MB. iOS' share sheet often refuses files ` +
+        `larger than ~100 MB and the share will silently fail. ` +
+        `Try anyway? (Use the download button instead if it fails.)`
+      );
+      if (!proceed) return;
     }
     try {
       const response = await fetch(this.buildDownloadLink(download));
@@ -1218,20 +1236,28 @@ export class App implements AfterViewInit, OnInit, OnDestroy {
       });
       const payload: ShareData = { files: [file], title: download.title };
       if (!navigator.canShare(payload)) {
-        // File type not shareable on this platform (e.g. desktop browsers,
-        // or some MIME types iOS refuses). Bail out so the user can still
-        // use the regular download button right next to this one.
+        // The platform refused the payload — most commonly because the
+        // file is too large for the iOS share sheet, or the MIME type
+        // isn't accepted. Tell the user so they can fall back to the
+        // download button right next to this one instead of staring at
+        // a button that quietly did nothing.
         console.warn('navigator.canShare rejected payload for', download.filename);
+        window.alert(
+          `Your device's share sheet doesn't accept this file ` +
+          `(most likely because it's too large). ` +
+          `Please use the download button instead.`
+        );
         return;
       }
       await navigator.share(payload);
     } catch (err: any) {
       // AbortError = user dismissed the share sheet → silent no-op.
-      // Other errors (network, file too big, …) get logged but we don't
-      // surface a UI error: the regular download link remains a fallback.
-      if (err?.name !== 'AbortError') {
-        console.error('Share failed:', err);
-      }
+      if (err?.name === 'AbortError') return;
+      console.error('Share failed:', err);
+      window.alert(
+        `Share failed: ${err?.message || 'unknown error'}. ` +
+        `Please use the download button instead.`
+      );
     }
   }
 

--- a/ui/src/app/app.ts
+++ b/ui/src/app/app.ts
@@ -7,7 +7,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { NgSelectModule } from '@ng-select/ng-select';  
-import { faTrashAlt, faCheckCircle, faTimesCircle, faRedoAlt, faSun, faMoon, faCheck, faCircleHalfStroke, faDownload, faExternalLinkAlt, faFileImport, faFileExport, faCopy, faClock, faTachometerAlt, faSortAmountDown, faSortAmountUp, faChevronRight, faChevronDown, faUpload, faPause, faPlay } from '@fortawesome/free-solid-svg-icons';
+import { faTrashAlt, faCheckCircle, faTimesCircle, faRedoAlt, faSun, faMoon, faCheck, faCircleHalfStroke, faDownload, faExternalLinkAlt, faFileImport, faFileExport, faCopy, faClock, faTachometerAlt, faSortAmountDown, faSortAmountUp, faChevronRight, faChevronDown, faUpload, faPause, faPlay, faShareNodes } from '@fortawesome/free-solid-svg-icons';
 import { faGithub } from '@fortawesome/free-brands-svg-icons';
 import { CookieService } from 'ngx-cookie-service';
 import { AddDownloadPayload, DownloadsService } from './services/downloads.service';
@@ -185,6 +185,7 @@ export class App implements AfterViewInit, OnInit, OnDestroy {
   faUpload = faUpload;
   faPause = faPause;
   faPlay = faPlay;
+  faShareNodes = faShareNodes;
   subtitleLanguages = [
     { id: 'en', text: 'English' },
     { id: 'ar', text: 'Arabic' },
@@ -1187,6 +1188,51 @@ export class App implements AfterViewInit, OnInit, OnDestroy {
     }
 
     return baseDir + encodeURIComponent(download.filename);
+  }
+
+  // Web Share API support — primarily for iOS Safari / Chrome, lets the user
+  // hand the downloaded file off to the platform share sheet (Photos.app,
+  // Files, third-party apps, AirDrop). Falls back silently to the standard
+  // download flow on platforms without navigator.share / canShare.
+  canShareDownloads(): boolean {
+    // navigator.share alone is not enough — Desktop Safari implements
+    // navigator.share but not canShare with files. We explicitly require
+    // both, since we always intend to share a file (not a URL).
+    return typeof navigator !== 'undefined'
+      && typeof navigator.share === 'function'
+      && typeof navigator.canShare === 'function';
+  }
+
+  async shareDownload(download: Download): Promise<void> {
+    if (!this.canShareDownloads()) {
+      return;
+    }
+    try {
+      const response = await fetch(this.buildDownloadLink(download));
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status} fetching file for share`);
+      }
+      const blob = await response.blob();
+      const file = new File([blob], download.filename, {
+        type: blob.type || 'application/octet-stream',
+      });
+      const payload: ShareData = { files: [file], title: download.title };
+      if (!navigator.canShare(payload)) {
+        // File type not shareable on this platform (e.g. desktop browsers,
+        // or some MIME types iOS refuses). Bail out so the user can still
+        // use the regular download button right next to this one.
+        console.warn('navigator.canShare rejected payload for', download.filename);
+        return;
+      }
+      await navigator.share(payload);
+    } catch (err: any) {
+      // AbortError = user dismissed the share sheet → silent no-op.
+      // Other errors (network, file too big, …) get logged but we don't
+      // surface a UI error: the regular download link remains a fallback.
+      if (err?.name !== 'AbortError') {
+        console.error('Share failed:', err);
+      }
+    }
   }
 
   buildResultItemTooltip(download: Download) {


### PR DESCRIPTION
## Motivation

Refs #582 — *"Update iOS shortcut so that the downloaded media is added to Photos.app"*.

Currently, on iOS the only way to land a downloaded video/photo in Photos.app is via the MeTube iOS Shortcut + a manual save step (and the Shortcut itself has had reliability issues — cf. #763). This PR proposes an in-app alternative: a small share button next to the existing download link in the *Completed* list that hands the file off to the platform share sheet via the [Web Share API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Share_API).

On iOS Safari/Chrome the share sheet surfaces "Save to Photos" automatically when the file is a video/image, and "Save to Files" / third-party-app targets when it's audio. One extra tap, fully native, no Shortcut required.

## What changes

- `ui/src/app/app.ts`: imports `faShareNodes`; adds two methods on `App`:
  - `canShareDownloads()` — feature-detects `navigator.share` **and** `navigator.canShare` (Desktop Safari has the former without file support; we always intend to share a `File`, so we need both)
  - `shareDownload(download)` — fetches the file via the existing `buildDownloadLink()` helper, wraps it in a `File`, runs `canShare()` against the payload, then `share()`. `AbortError` (user dismisses sheet) is silenced; other failures get logged.
- `ui/src/app/app.html`: adds an `@if (entry[1].filename && canShareDownloads())` conditional button between the download link and the source-URL link. Tooltip explains the iOS behaviour.

50 lines added, 1 removed. No changes to the backend, no changes to existing behaviour for platforms without Web Share API support — the button simply doesn't render, and the original download link remains the universal fallback.

## Why this design

- **No new dependency.** Web Share API is built into all major browsers.
- **Progressive enhancement.** Desktop Firefox/Chrome/Safari users see no change. iOS users gain one tap to native share targets.
- **Respects existing flow.** Sits next to the download link, not replacing it.
- **Audio gets useful targets too.** Not just photos — share sheet shows Files, AirDrop, third-party players for `.mp3`/`.m4a`.

## Testing

Verified locally:
- ✅ Bundle builds (`pnpm build`, no new warnings/errors)
- ✅ Container starts, HTTP 200 from UI
- ✅ Bundle contains the new symbols (`shareDownload`, `canShareDownloads`)
- ✅ Existing download flow unaffected (download link still works on all browsers)

Manual iOS testing recommended before merge — the actual share-sheet behaviour depends on iOS version + file MIME type. I am running this on a self-hosted instance with iOS Safari/Chrome (iOS 17/18), `.mp4` and `.mp3` files; the share sheet shows the expected options. Happy to add screenshots if useful.

## Caveats / edge cases

- **Large files.** iOS has a soft limit (~50–100 MB depending on version) for files in the share sheet. Files exceeding it cause `share()` to fail → `console.error`; the regular download link remains usable. Open to adding a pre-flight size check + UI warning if preferred.
- **CORS / fetch.** The file is fetched via the same-origin `buildDownloadLink()`, so no CORS surprises.
- **Caching.** `fetch()` benefits from browser cache; the file is not re-downloaded if the user already clicked the download link first.

## Out of scope (intentional)

- No new dependency on file-saver libraries.
- No changes to the download endpoint or filename generation.
- No tests added — happy to add if reviewers prefer; the methods are mostly thin wrappers around platform APIs that are difficult to mock meaningfully.