### PR TITLE
feat(ui): show actually-downloaded resolution/bitrate in completed list

### DIFF
--- a/app/ytdl.py
+++ b/app/ytdl.py
@@ -231,10 +231,24 @@ class DownloadInfo:
         self.live_status = live_status
         self.live_release_timestamp = live_release_timestamp
         self.subtitle_files = []
+        # Actual media properties captured from yt-dlp's info_dict when the
+        # download finishes. Unlike `quality`/`codec` (the user's request),
+        # these reflect what yt-dlp actually resolved to. Set lazily by the
+        # MoveFiles postprocessor hook, so they stay None for in-flight,
+        # failed, or non-media (captions/thumbnail) downloads.
+        self.width = None
+        self.height = None
+        self.fps = None
+        self.vcodec_actual = None
+        self.abr = None
 
     def __setstate__(self, state):
         """BACKWARD COMPATIBILITY: migrate old DownloadInfo from persistent queue files."""
         self.__dict__.update(state)
+        # Backfill resolved-media fields for items persisted before this patch.
+        for field in ('width', 'height', 'fps', 'vcodec_actual', 'abr'):
+            if not hasattr(self, field):
+                setattr(self, field, None)
         if 'download_type' not in state:
             old_format = state.get('format', 'any')
             old_video_codec = state.get('video_codec', 'auto')
@@ -454,7 +468,21 @@ class Download:
                         filename = os.path.join(finaldir, os.path.basename(filepath))
                     else:
                         filename = filepath
-                    self.status_queue.put({'status': 'finished', 'filename': filename})
+                    status_update = {'status': 'finished', 'filename': filename}
+                    # Capture actual media properties resolved by yt-dlp so the
+                    # UI can show "Best · 1080p60" instead of just "Best".
+                    # Skip vcodec='none' (audio-only formats) — that's not the
+                    # video codec, it just means there isn't one.
+                    info = d['info_dict']
+                    for src, dst in (('width', 'width'), ('height', 'height'),
+                                     ('fps', 'fps'), ('abr', 'abr')):
+                        value = info.get(src)
+                        if value is not None:
+                            status_update[dst] = value
+                    vcodec = info.get('vcodec')
+                    if vcodec and vcodec != 'none':
+                        status_update['vcodec_actual'] = vcodec
+                    self.status_queue.put(status_update)
                     # For captions-only downloads, yt-dlp may still report a media-like
                     # filepath in MoveFiles. Capture subtitle outputs explicitly so the
                     # UI can link to real caption files.
@@ -585,6 +613,12 @@ class Download:
                 self.info.size = os.path.getsize(fileName) if os.path.exists(fileName) else None
                 if getattr(self.info, 'download_type', '') == 'thumbnail':
                     self.info.filename = re.sub(r'\.webm$', '.jpg', self.info.filename)
+            # Capture actual media properties yt-dlp resolved (width / height /
+            # fps / actual vcodec / audio bitrate). Pushed by the MoveFiles
+            # postprocessor hook; never overwrite a present value with None.
+            for field in ('width', 'height', 'fps', 'vcodec_actual', 'abr'):
+                if field in status and status[field] is not None:
+                    setattr(self.info, field, status[field])
 
             # Handle chapter files
             log.debug(f"Update status for {self.info.title}: {status}")

--- a/ui/src/app/app.ts
+++ b/ui/src/app/app.ts
@@ -862,9 +862,34 @@ export class App implements AfterViewInit, OnInit, OnDestroy {
     }
     const q = download.quality;
     if (!q) return '';
-    if (/^\d+$/.test(q) && download.download_type === 'audio') return `${q} kbps`;
+    const requested = this.formatRequestedQuality(q, download.download_type);
+    const actual = this.formatActualQuality(download);
+    // Show the actual value next to the requested one only when it differs
+    // — most useful for "Best" / "Worst" (no exact label) or when yt-dlp
+    // had to downgrade (user requested 1080p, only 720p was available).
+    if (!actual || actual === requested) return requested;
+    return `${requested} · ${actual}`;
+  }
+
+  private formatRequestedQuality(q: string, dl_type: string): string {
+    if (/^\d+$/.test(q) && dl_type === 'audio') return `${q} kbps`;
     if (/^\d+$/.test(q)) return `${q}p`;
     return q.charAt(0).toUpperCase() + q.slice(1);
+  }
+
+  // Returns the actually-resolved quality from yt-dlp's info_dict
+  // (height+fps for video, abr for audio). Returns null for old persisted
+  // entries that pre-date the backend patch, or for non-media types.
+  private formatActualQuality(download: Download): string | null {
+    if (download.download_type === 'audio') {
+      return download.abr ? `${Math.round(download.abr)} kbps` : null;
+    }
+    if (!download.height) return null;
+    let label = `${download.height}p`;
+    // High frame rates (50+) are worth highlighting; standard 24/25/30
+    // would clutter without telling the user anything new.
+    if (download.fps && download.fps >= 50) label += Math.round(download.fps);
+    return label;
   }
 
   downloadTypeLabel(download: Download): string {

--- a/ui/src/app/interfaces/download.ts
+++ b/ui/src/app/interfaces/download.ts
@@ -32,4 +32,14 @@ export interface Download {
   error?: string;
   deleting?: boolean;
   chapter_files?: { filename: string, size: number }[];
+  // Actual media properties resolved by yt-dlp at download time. Unlike
+  // `quality`/`codec` (the user's request), these reflect what came out.
+  // Optional because they're only populated for finished downloads of
+  // video/audio (not captions/thumbnails) and old persisted entries
+  // pre-dating the patch don't have them.
+  width?: number;
+  height?: number;
+  fps?: number;
+  vcodec_actual?: string;
+  abr?: number;
 }


### PR DESCRIPTION
## Motivation

The completed-downloads list currently shows the user's *requested* quality (`Best`, `1080p`, `320 kbps`), but yt-dlp may resolve that to anything from 360p to 4K60 depending on what the source actually offers. The user has no way to tell after the fact what came down — was that "Best" video 720p30 or 2160p60?

This bites in a few common scenarios:
- `Best` selected — what did you actually get?
- `1080p` selected but only `720p` was available → silent downgrade (cf. closed #745)
- `320 kbps` audio — did you get a 320 source or did yt-dlp fall back to 256?

The information is right there in `info_dict` at the MoveFiles postprocessor hook — MeTube just doesn't persist it. This PR plumbs four optional fields through and renders the actual value next to the requested one when they differ.

## What changes

### Backend (`app/ytdl.py`)

- `DownloadInfo.__init__`: five new optional fields, all defaulting to `None`:
  `width`, `height`, `fps`, `vcodec_actual`, `abr`.
- `DownloadInfo.__setstate__`: backfills `None` for items persisted before this patch so old `completed.json` entries keep loading cleanly.
- `put_status_postprocessor` (`MoveFiles` / `finished`): pulls `width`/`height`/`fps`/`abr` straight from `d['info_dict']` and adds `vcodec_actual` only when `vcodec` is present and != `'none'` (skipping audio-only formats where `vcodec='none'` just means there isn't one).
- `update_status`: applies the five fields to `self.info` without overwriting present values with `None`.

### Frontend (`ui/src/app/interfaces/download.ts`)

Five new optional fields on `Download` mirroring the backend.

### Frontend (`ui/src/app/app.ts:formatQualityLabel`)

Refactored into three helpers:
- `formatQualityLabel` — orchestrates and joins with a middle-dot
- `formatRequestedQuality` — what the user picked (unchanged logic)
- `formatActualQuality` — what yt-dlp actually delivered

Examples of the resulting labels:

| User pick | Actual | Rendered |
|---|---|---|
| Best | 1080p60 video | `Best · 1080p60` |
| Best | 720p30 video | `Best · 720p` |
| Best | 2160p60 video | `Best · 2160p60` |
| 1080 | 720p (downgrade) | `1080p · 720p` |
| 1080 | 1080p (exact) | `1080p` *(collapsed — no noise)* |
| Best audio | 320 kbps | `Best · 320 kbps` |
| Old persisted entry | — (no data) | `Best` *(unchanged)* |

`fps` is appended only at 50+ (so 60fps gets marked, 24/25/30 stay implicit — they would just clutter without telling the user anything new).

## Backward compatibility

- Old persisted `completed.json` entries don't have the new fields. `__setstate__` backfills them to `None`, and `formatActualQuality()` returns `null` in that case → label rendering is identical to before. No data migration needed.
- For chapters / captions / thumbnails the label code path was unchanged (`return '-'` short-circuits early).

## Testing

Verified locally:
- ✅ `docker compose build` succeeds, `pnpm build` clean.
- ✅ Bundle contains the new helper symbols and the static labels.
- ✅ A pre-patch completed item ("Me at the zoo", 360p) loads with just `Best` (no width/height in the persisted info → label unchanged).
- ✅ A post-patch completed item populates the new fields and renders `Best · …` as expected.
- ✅ Backend doesn't crash if `info_dict` doesn't have any of the fields (each is `info.get(...)`-guarded individually).

## Refs

- #222 "Know Video Quality before download" — related, but about *pre*-download visibility. This PR addresses the *post*-download side.
- #745 "1080p MP4 download often falls back to 640x360" — exactly the silent-downgrade case this PR makes visible.