### PR TITLE
fix(ytdl): trash button should also remove sidecars and empty parents

### DIFF
--- a/app/ytdl.py
+++ b/app/ytdl.py
@@ -1389,12 +1389,68 @@ class DownloadQueue:
                 dl = self.done.get(id)
                 try:
                     dldirectory, _ = self.__calc_download_path(dl.info.download_type, dl.info.folder)
-                    os.remove(os.path.join(dldirectory, dl.info.filename))
+                    self.__remove_download_and_sidecars(dldirectory, dl.info.filename)
                 except Exception as e:
                     log.warning(f'deleting file for download {id} failed with error message {e!r}')
             self.done.delete(id)
             await self.notifier.cleared(id)
         return {'status': 'ok'}
+
+    def __remove_download_and_sidecars(self, bucket_root, rel_filename):
+        """When DELETE_FILE_ON_TRASHCAN is enabled, the trash button should
+        leave the bucket the way it found it: no orphan thumbnail / subtitle
+        / info.json files, no empty `<uploader>/` directories left behind.
+
+        Removes:
+          1. the main file the download record references
+          2. every same-stem sidecar in the same directory
+             (writethumbnail's .jpg/.webp, writesubtitles' .vtt/.srt,
+              writeinfojson's .info.json, writedescription's .description,
+              anything else yt-dlp writes per video)
+          3. any directories from the file's parent up to (but not including)
+             the bucket root, while they're empty after the removals above
+
+        Never touches the bucket root itself (e.g. /downloads/helmut), and
+        os.rmdir() is non-destructive — it raises if the directory still
+        contains anything, which is exactly the desired behaviour."""
+        main_path = os.path.join(bucket_root, rel_filename)
+        main_dir = os.path.dirname(main_path)
+        main_stem, _ = os.path.splitext(os.path.basename(main_path))
+        # Sidecar prefix matches the main file and anything yt-dlp wrote
+        # alongside it (e.g. "Title [id].jpg", "Title [id].en.vtt",
+        # "Title [id].info.json"). The trailing dot avoids matching a
+        # sibling whose name starts with the same stem but continues
+        # with other characters (e.g. "Title [id] (alt cut).mp4").
+        sidecar_prefix = main_stem + '.'
+        if os.path.isdir(main_dir):
+            for entry in os.listdir(main_dir):
+                if not entry.startswith(sidecar_prefix):
+                    continue
+                entry_path = os.path.join(main_dir, entry)
+                if not os.path.isfile(entry_path):
+                    continue
+                try:
+                    os.remove(entry_path)
+                except OSError as e:
+                    log.warning(f'failed to remove sidecar {entry_path}: {e!r}')
+
+        # Prune empty parent directories up to (but not including)
+        # bucket_root. Walk on realpath()ed paths so a symlinked layout
+        # can't trick us into climbing above the bucket.
+        try:
+            bucket_real = os.path.realpath(bucket_root)
+            cur = os.path.realpath(main_dir)
+            while cur != bucket_real and cur.startswith(bucket_real + os.sep):
+                try:
+                    os.rmdir(cur)
+                except OSError:
+                    # Directory is non-empty (or a permission issue) —
+                    # in either case stop climbing, that's the signal
+                    # to leave it alone.
+                    break
+                cur = os.path.dirname(cur)
+        except Exception as e:
+            log.warning(f'failed to prune empty parents below {bucket_root}: {e!r}')
 
     def get(self):
         return (list((k, v.info) for k, v in self.queue.items()) +


### PR DESCRIPTION
## Motivation

With `DELETE_FILE_ON_TRASHCAN=true`, the trash icon next to a completed download removes the *one* file the download record points at, but leaves behind:

- **Sidecar files yt-dlp wrote alongside the video** — `.jpg`/`.webp` thumbnails (from `writethumbnail`), `.vtt`/`.srt` subtitles (from `writesubtitles`), `.info.json` (from `writeinfojson`), `.description` (from `writedescription`), etc.
- **The per-uploader directory** that the output template usually creates — once the video is gone it's often empty, but it still sits there.

From the user's perspective the trash button claims to delete the item but really only removes the main MP4. Most setups that turn on `DELETE_FILE_ON_TRASHCAN` also have at least `writethumbnail` (it's a common combo for nicer-looking files), so this lands as soon as someone deletes their first item.

## What changes

`clear()` keeps its current control flow. The actual filesystem work moves into a private helper `__remove_download_and_sidecars` that does two passes:

1. **Sidecar pass** — `os.listdir()` of the file's directory once, removing every entry whose name starts with `<main-stem>.`. Trailing dot prevents collateral hits on siblings like `Title [id] (alt).mp4` that happen to share a prefix.

2. **Empty-parent pass** — walks upwards with `os.rmdir()`, which is non-destructive (raises `OSError` the moment a directory is non-empty), so it self-stops. Hard limit at the bucket root (`__calc_download_path`'s return). Both sides `realpath()`'d so a symlinked tree can't fool the walk above the bucket.

Net effect: after `clear()`, the directory structure looks like it did before the download ever happened.

## What it does **not** change

- No new environment variables, no new feature flags. `DELETE_FILE_ON_TRASHCAN` is the only switch and its current behaviour for the simple "no sidecars, files in `DOWNLOAD_DIR` root" case is unchanged.
- The behaviour when `DELETE_FILE_ON_TRASHCAN` is `false` (the default) is untouched.
- The bucket root and anything above it is never touched.
- Failures during sidecar removal or directory pruning are logged as warnings, not raised — the trash semantics never get blocked by a file-system hiccup.

## Diff size

+57 / −1 in `app/ytdl.py`. No other files affected.

## Testing

- ✅ `python3 -c "import ast; ast.parse(open('app/ytdl.py').read())"` passes.
- ✅ Built locally, deployed to a self-hosted instance with `writethumbnail: true`. Created downloads in a `<uploader>/` subdirectory, hit trash, verified the directory and the `.jpg` sidecar both disappeared. Re-tested with two downloads in the same `<uploader>/` directory — deleting one removes that one's sidecar but leaves the directory plus the second video intact.
- ✅ Re-tested with `DELETE_FILE_ON_TRASHCAN=false` (default) — `clear()` skips the new helper entirely, no behaviour change.

Happy to add unit tests around the helper if reviewers prefer; the logic is small and self-contained so it should mock cleanly.