### PR TITLE
docs: add local-only Docker profile for MeTube

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,15 @@
+services:
+  metube:
+    image: ghcr.io/alexta69/metube
+    container_name: metube-local
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:8081:8081"
+    volumes:
+      - ./downloads:/downloads
+    environment:
+      - DOWNLOAD_DIR=/downloads
+      - DOWNLOAD_DIRS_INDEXABLE=false
+      - ALLOW_YTDL_OPTIONS_OVERRIDES=false
+      - CORS_ALLOWED_ORIGINS=
+      - ENABLE_ACCESSLOG=false

--- a/docs/local-only.md
+++ b/docs/local-only.md
@@ -1,0 +1,68 @@
+# Local-only Docker profile
+
+この構成は、MeTube をローカルPCからのみ使うための Docker 起動プロファイルです。対象は、自分の動画、許可済み動画、または合法利用できる動画だけです。Web公開、外部ユーザーへの提供、広告収益化、アクセス制限の回避を目的にしません。
+
+コンテナはホスト側の loopback interface のみに公開します。
+
+```text
+http://127.0.0.1:8081/
+```
+
+## 起動
+
+```powershell
+docker compose -f docker-compose.local.yml up -d
+```
+
+ブラウザでは次のURLを開きます。
+
+```text
+http://127.0.0.1:8081/
+```
+
+同じPC上では `http://localhost:8081/` でもアクセスできる想定です。
+
+## 停止
+
+```powershell
+docker compose -f docker-compose.local.yml down
+```
+
+## ログ確認
+
+```powershell
+docker compose -f docker-compose.local.yml logs --tail=80
+```
+
+## PowerShellでのポート確認
+
+PowerShellで、待ち受けがローカル専用になっていることを確認します。
+
+```powershell
+Get-NetTCPConnection -LocalPort 8081 | Select-Object LocalAddress,LocalPort,State,OwningProcess
+```
+
+`LocalAddress` が `127.0.0.1` であることを確認します。`0.0.0.0` やLAN IPで待ち受けている場合は、利用せずに停止して compose 設定を修正してください。
+
+ローカルアクセスは次のコマンドでも確認できます。
+
+```powershell
+curl http://127.0.0.1:8081/
+curl http://localhost:8081/
+```
+
+## この構成で使わないもの
+
+このローカル専用プロファイルでは、reverse proxy、HTTPS、`PUBLIC_HOST_URL`、browser extension、CORS `*` は使いません。
+
+このリポジトリに cookie、token、secret を保存・表示しないでください。DRM回避、認証突破、制限回避、大量取得最適化は対象外です。
+
+## 検証済み環境
+
+- 検証日: 2026-06-06
+- 実行環境: Windows + Docker Desktop
+- `docker compose -f docker-compose.local.yml config`: `host_ip: 127.0.0.1` を確認
+- `http://127.0.0.1:8081/`: アクセス確認済み
+- `http://localhost:8081/`: アクセス確認済み
+- `Get-NetTCPConnection -LocalPort 8081`: `LocalAddress` が `127.0.0.1` であることを確認
+- `docker compose -f docker-compose.local.yml down`: 停止確認済み


### PR DESCRIPTION
## Summary
- Add a local-only Docker Compose profile for MeTube
- Bind the host port to `127.0.0.1:8081`
- Bind the host port with the exact compose mapping: `127.0.0.1:8081:8081`
- Document local-only startup, verification, logs, and shutdown
- Record verified Windows + Docker Desktop startup results

## Safety
- backend/frontend/yt-dlp unchanged
- no public host URL
- no CORS wildcard
- no indexable download dirs
- no yt-dlp option overrides
- no cookie/token/secret handling
- no reverse proxy or external publishing setup

## Verification
- `git diff --check`
- `docker compose -f docker-compose.local.yml config`
- `docker compose -f docker-compose.local.yml up -d`
- `curl http://127.0.0.1:8081/`
- `curl http://localhost:8081/`
- `Get-NetTCPConnection -LocalPort 8081`
- `docker compose -f docker-compose.local.yml logs --tail=80`
- `docker compose -f docker-compose.local.yml down`
- stopped state: no listener on port 8081