### PR TITLE
Create AUDIO_DOWNLOAD_DIR in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,7 @@ ENV PGID=1000
 ENV UMASK=022
 
 ENV DOWNLOAD_DIR=/downloads
+ENV AUDIO_DOWNLOAD_DIR=/downloads
 ENV STATE_DIR=/downloads/.metube
 ENV TEMP_DIR=/downloads
 ENV PORT=8081

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,6 @@ ENV PGID=1000
 ENV UMASK=022
 
 ENV DOWNLOAD_DIR=/downloads
-ENV AUDIO_DOWNLOAD_DIR=/downloads
 ENV STATE_DIR=/downloads/.metube
 ENV TEMP_DIR=/downloads
 ENV PORT=8081

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,6 +2,7 @@
 
 PUID="${UID:-$PUID}"
 PGID="${GID:-$PGID}"
+AUDIO_DOWNLOAD_DIR="${AUDIO_DOWNLOAD_DIR:-$DOWNLOAD_DIR}"
 
 echo "Setting umask to ${UMASK}"
 umask ${UMASK}

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,8 +5,8 @@ PGID="${GID:-$PGID}"
 
 echo "Setting umask to ${UMASK}"
 umask ${UMASK}
-echo "Creating download directory (${DOWNLOAD_DIR}), state directory (${STATE_DIR}), and temp dir (${TEMP_DIR})"
-mkdir -p "${DOWNLOAD_DIR}" "${STATE_DIR}" "${TEMP_DIR}"
+echo "Creating download directory (${DOWNLOAD_DIR}), audio download directory (${AUDIO_DOWNLOAD_DIR}), state directory (${STATE_DIR}), and temp dir (${TEMP_DIR})"
+mkdir -p "${DOWNLOAD_DIR}" "${AUDIO_DOWNLOAD_DIR}" "${STATE_DIR}" "${TEMP_DIR}"
 
 do_upgrade() {
     echo "Upgrading yt-dlp to nightly channel..."
@@ -56,7 +56,7 @@ if [ `id -u` -eq 0 ] && [ `id -g` -eq 0 ]; then
     fi
     if [ "${CHOWN_DIRS:-true}" != "false" ]; then
         echo "Changing ownership of download and state directories to ${PUID}:${PGID}"
-        chown -R "${PUID}":"${PGID}" /app "${DOWNLOAD_DIR}" "${STATE_DIR}" "${TEMP_DIR}"
+        chown -R "${PUID}":"${PGID}" /app "${DOWNLOAD_DIR}" "${AUDIO_DOWNLOAD_DIR}" "${STATE_DIR}" "${TEMP_DIR}"
     fi
     if nightly_enabled; then
         echo "YTDL_NIGHTLY_UPDATE_TIME is set to ${YTDL_NIGHTLY_UPDATE_TIME}; upgrading yt-dlp on startup"


### PR DESCRIPTION
Setting the `AUDIO_DOWNLOAD_DIR` environment variable when using Docker Compose causes errors because the directory isn't created.  This PR adds `AUDIO_DOWNLOAD_DIR` to the directory creation commands in `docker-entrypoint.sh`. It also explicitly sets the default value for `AUDIO_DOWNLOAD_DIR` in the `Dockerfile` so that an unset `AUDIO_DOWNLOAD_DIR` doesn't cause errors in `docker-entrypoint.sh`.

This is the `compose.yaml` I used for testing:

```yaml
services:
  metube:
    build: .
    container_name: metube
    ports:
      - "8081:8081"
    environment:
      DOWNLOAD_DIR: /downloads/video
      AUDIO_DOWNLOAD_DIR: /downloads/audio
    volumes:
      - metube-downloads:/downloads

volumes:
  metube-downloads:
```

And the command:
```bash
docker compose build && docker compose up -d && docker compose logs -f
```

Logs before the PR changes:

> metube  | Setting umask to 022
> metube  | Creating download directory (/downloads/video), state directory (/downloads/.metube), and temp dir (/downloads)
> metube  | Changing ownership of download and state directories to 1000:1000
> metube  | Starting BgUtils POT Provider
> metube  | Running MeTube as user 1000:1000
> metube  | Traceback (most recent call last):
> metube  |   File "/usr/local/lib/python3.13/site-packages/aiohttp/web_urldispatcher.py", line 568, in __init__
> metube  |     directory = Path(directory).expanduser().resolve(strict=True)
> metube  |   File "/usr/local/lib/python3.13/pathlib/_local.py", line 670, in resolve
> metube  |     return self.with_segments(os.path.realpath(self, strict=strict))
> metube  |                               ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
> metube  |   File "<frozen posixpath>", line 451, in realpath
> metube  | FileNotFoundError: [Errno 2] No such file or directory: '/downloads/audio'
> metube  | 
> metube  | The above exception was the direct cause of the following exception:
> metube  | 
> metube  | Traceback (most recent call last):
> metube  |   File "/app/app/main.py", line 1135, in <module>
> metube  |     raise e
> metube  |   File "/app/app/main.py", line 1131, in <module>
> metube  |     app.add_routes(routes)
> metube  |     ~~~~~~~~~~~~~~^^^^^^^^
> metube  |   File "/usr/local/lib/python3.13/site-packages/aiohttp/web_app.py", line 389, in add_routes
> metube  |     return self.router.add_routes(routes)
> metube  |            ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
> metube  |   File "/usr/local/lib/python3.13/site-packages/aiohttp/web_urldispatcher.py", line 1287, in add_routes
> metube  |     registered_routes.extend(route_def.register(self))
> metube  |                              ~~~~~~~~~~~~~~~~~~^^^^^^
> metube  |   File "/usr/local/lib/python3.13/site-packages/aiohttp/web_routedef.py", line 98, in register
> metube  |     resource = router.add_static(self.prefix, self.path, **self.kwargs)
> metube  |   File "/usr/local/lib/python3.13/site-packages/aiohttp/web_urldispatcher.py", line 1211, in add_static
> metube  |     resource = StaticResource(
> metube  |         prefix,
> metube  |     ...<6 lines>...
> metube  |         append_version=append_version,
> metube  |     )
> metube  |   File "/usr/local/lib/python3.13/site-packages/aiohttp/web_urldispatcher.py", line 570, in __init__
> metube  |     raise ValueError(f"'{directory}' does not exist") from error
> metube  | ValueError: '/downloads/audio' does not exist
> metube exited with code 1

Logs after the PR changes:

> metube  | Setting umask to 022
> metube  | Creating download directory (/downloads/video), audio download directory (/downloads/audio), state directory (/downloads/.metube), and temp dir (/downloads)
> metube  | Changing ownership of download and state directories to 1000:1000
> metube  | Starting BgUtils POT Provider
> metube  | Running MeTube as user 1000:1000
> metube  | INFO:main:Listening on 0.0.0.0:8081
> metube  | INFO:ytdl:Initializing DownloadQueue
> [...]