### PR TITLE
fix(ytdl): skip file deletion for cleared downloads that never produced a file

### DIFF
--- a/app/ytdl.py
+++ b/app/ytdl.py
@@ -1387,11 +1387,18 @@ class DownloadQueue:
                 continue
             if self.config.DELETE_FILE_ON_TRASHCAN:
                 dl = self.done.get(id)
-                try:
-                    dldirectory, _ = self.__calc_download_path(dl.info.download_type, dl.info.folder)
-                    os.remove(os.path.join(dldirectory, dl.info.filename))
-                except Exception as e:
-                    log.warning(f'deleting file for download {id} failed with error message {e!r}')
+                # `filename` is only set once a download has produced a file; a
+                # download that errored (or was cleared) before that point never
+                # gets one. Skip deletion instead of dereferencing a missing
+                # attribute, which otherwise logs a misleading
+                # "deleting file ... failed: AttributeError" warning.
+                filename = getattr(dl.info, 'filename', None)
+                if filename:
+                    try:
+                        dldirectory, _ = self.__calc_download_path(dl.info.download_type, dl.info.folder)
+                        os.remove(os.path.join(dldirectory, filename))
+                    except Exception as e:
+                        log.warning(f'deleting file for download {id} failed with error message {e!r}')
             self.done.delete(id)
             await self.notifier.cleared(id)
         return {'status': 'ok'}


### PR DESCRIPTION
## Problem

With `DELETE_FILE_ON_TRASHCAN` enabled, clearing a download that never produced a file — e.g. one that errored during/ before post-processing — logs a misleading warning:

```
deleting file for download <url> failed with error message AttributeError("'DownloadInfo' object has no attribute 'filename'")
```

`DownloadInfo.filename` is only set once an output file exists. For a download that failed before that point the attribute is absent, so

```python
os.remove(os.path.join(dldirectory, dl.info.filename))
```

raises `AttributeError`. It's caught by the surrounding `except`, so nothing breaks functionally and the entry is still cleared — but every such clear emits a confusing "deleting file … failed" warning even though there was never a file to delete.

## Fix

Read `filename` via `getattr(dl.info, 'filename', None)` and only attempt deletion when it is set. No behaviour change for downloads that did produce a file.

## Reproduce

Set `DELETE_FILE_ON_TRASHCAN=true`, queue a URL that fails before producing a file (e.g. a Facebook reel whose post-processing errors out), then clear the entry → observe the `AttributeError` warning in the log. With the patch the clear is silent (nothing to remove).

Single-file, minimal change. Found while running a self-hosted instance.
