### PR TITLE
fix: blank PUBLIC_HOST_AUDIO_URL no longer breaks audio download links

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -117,6 +117,10 @@ class Config:
             if val and not val.endswith('/'):
                 setattr(self, attr, val + '/')
 
+        # A blank PUBLIC_HOST_AUDIO_URL inherits PUBLIC_HOST_URL so audio links aren't left root-relative; both blank stays blank.
+        if not self.PUBLIC_HOST_AUDIO_URL:
+            self.PUBLIC_HOST_AUDIO_URL = self.PUBLIC_HOST_URL
+
         # Convert relative addresses to absolute addresses to prevent the failure of file address comparison
         if self.YTDL_OPTIONS_FILE and self.YTDL_OPTIONS_FILE.startswith('.'):
             self.YTDL_OPTIONS_FILE = str(Path(self.YTDL_OPTIONS_FILE).resolve())

--- a/app/tests/test_config.py
+++ b/app/tests/test_config.py
@@ -51,6 +51,43 @@ class ConfigTests(unittest.TestCase):
         self.assertEqual(c.PUBLIC_HOST_URL, "")
         self.assertEqual(c.PUBLIC_HOST_AUDIO_URL, "")
 
+    def test_blank_audio_host_inherits_public_host_url(self):
+        # Regression: a blank PUBLIC_HOST_AUDIO_URL must inherit PUBLIC_HOST_URL, not stay root-relative.
+        with patch.dict(
+            os.environ,
+            _base_env(PUBLIC_HOST_URL="download/", PUBLIC_HOST_AUDIO_URL=""),
+            clear=False,
+        ):
+            c = Config()
+        self.assertEqual(c.PUBLIC_HOST_URL, "download/")
+        self.assertEqual(c.PUBLIC_HOST_AUDIO_URL, "download/")
+
+    def test_blank_audio_host_audio_link_is_not_root_relative(self):
+        # Repro of the reported bug. buildDownloadLink uses configuration[PUBLIC_HOST_AUDIO_URL]
+        # as the base for audio, so a blank value made the link "song.mp3" (root-relative, 404)
+        # while video kept working off PUBLIC_HOST_URL. The base must be prefixed instead.
+        with patch.dict(
+            os.environ,
+            _base_env(PUBLIC_HOST_URL="download/", PUBLIC_HOST_AUDIO_URL=""),
+            clear=False,
+        ):
+            c = Config()
+        audio_link = c.PUBLIC_HOST_AUDIO_URL + "song.mp3"
+        video_link = c.PUBLIC_HOST_URL + "video.mp4"
+        self.assertEqual(video_link, "download/video.mp4")
+        self.assertNotEqual(audio_link, "song.mp3")
+        self.assertEqual(audio_link, "download/song.mp3")
+
+    def test_unset_audio_host_keeps_default_route(self):
+        # Truly unset (not blank) keeps the 'audio_download/' default route.
+        env = _base_env()
+        env.pop("PUBLIC_HOST_AUDIO_URL", None)
+        env.pop("PUBLIC_HOST_URL", None)
+        with patch.dict(os.environ, env, clear=True):
+            c = Config()
+        self.assertEqual(c.PUBLIC_HOST_URL, "download/")
+        self.assertEqual(c.PUBLIC_HOST_AUDIO_URL, "audio_download/")
+
     def test_public_host_url_already_slashed_unchanged(self):
         with patch.dict(
             os.environ,

--- a/ui/src/app/app.spec.ts
+++ b/ui/src/app/app.spec.ts
@@ -305,6 +305,30 @@ describe('App', () => {
     expect(app.buildDownloadLink(makeDownload())).toBe('song.mp3');
   });
 
+  it('builds chapter audio link from PUBLIC_HOST_AUDIO_URL when set', () => {
+    downloads.configuration['PUBLIC_HOST_URL'] = 'download/';
+    downloads.configuration['PUBLIC_HOST_AUDIO_URL'] = 'audio_download/';
+    const app = TestBed.createComponent(App).componentInstance;
+    const link = app.buildChapterDownloadLink(makeDownload(), 'chapter1.mp3');
+    expect(link).toBe('audio_download/chapter1.mp3');
+  });
+
+  it('chapter audio link falls back to PUBLIC_HOST_URL when audio host is blank (regression)', () => {
+    downloads.configuration['PUBLIC_HOST_URL'] = 'download/';
+    downloads.configuration['PUBLIC_HOST_AUDIO_URL'] = '';
+    const app = TestBed.createComponent(App).componentInstance;
+    const link = app.buildChapterDownloadLink(makeDownload(), 'chapter1.mp3');
+    expect(link).not.toBe('chapter1.mp3');
+    expect(link).toBe('download/chapter1.mp3');
+  });
+
+  it('chapter audio link stays root-relative when both hosts are blank', () => {
+    downloads.configuration['PUBLIC_HOST_URL'] = '';
+    downloads.configuration['PUBLIC_HOST_AUDIO_URL'] = '';
+    const app = TestBed.createComponent(App).componentInstance;
+    expect(app.buildChapterDownloadLink(makeDownload(), 'chapter1.mp3')).toBe('chapter1.mp3');
+  });
+
   it('blocks subscribe with invalid title regex', () => {
     const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => undefined);
     const fixture = TestBed.createComponent(App);

--- a/ui/src/app/app.spec.ts
+++ b/ui/src/app/app.spec.ts
@@ -262,6 +262,49 @@ describe('App', () => {
     expect(payload.clipEnd).toBe('1:20');
   });
 
+  function makeDownload(overrides: Record<string, unknown> = {}) {
+    return {
+      download_type: 'audio',
+      filename: 'song.mp3',
+      folder: '',
+      title: 'Song',
+      ...overrides,
+    } as unknown as Parameters<App['buildDownloadLink']>[0];
+  }
+
+  it('builds audio link from PUBLIC_HOST_AUDIO_URL when set', () => {
+    downloads.configuration['PUBLIC_HOST_URL'] = 'download/';
+    downloads.configuration['PUBLIC_HOST_AUDIO_URL'] = 'audio_download/';
+    const app = TestBed.createComponent(App).componentInstance;
+    expect(app.buildDownloadLink(makeDownload())).toBe('audio_download/song.mp3');
+  });
+
+  it('builds video link from PUBLIC_HOST_URL', () => {
+    downloads.configuration['PUBLIC_HOST_URL'] = 'download/';
+    downloads.configuration['PUBLIC_HOST_AUDIO_URL'] = 'audio_download/';
+    const app = TestBed.createComponent(App).componentInstance;
+    const link = app.buildDownloadLink(makeDownload({ download_type: 'video', filename: 'video.mp4' }));
+    expect(link).toBe('download/video.mp4');
+  });
+
+  it('audio link falls back to PUBLIC_HOST_URL when audio host is blank (regression)', () => {
+    // The reported bug: a blank PUBLIC_HOST_AUDIO_URL produced a root-relative
+    // "song.mp3" that 404'd while video kept working. It must not be root-relative.
+    downloads.configuration['PUBLIC_HOST_URL'] = 'download/';
+    downloads.configuration['PUBLIC_HOST_AUDIO_URL'] = '';
+    const app = TestBed.createComponent(App).componentInstance;
+    const link = app.buildDownloadLink(makeDownload());
+    expect(link).not.toBe('song.mp3');
+    expect(link).toBe('download/song.mp3');
+  });
+
+  it('audio link stays root-relative when both hosts are blank', () => {
+    downloads.configuration['PUBLIC_HOST_URL'] = '';
+    downloads.configuration['PUBLIC_HOST_AUDIO_URL'] = '';
+    const app = TestBed.createComponent(App).componentInstance;
+    expect(app.buildDownloadLink(makeDownload())).toBe('song.mp3');
+  });
+
   it('blocks subscribe with invalid title regex', () => {
     const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => undefined);
     const fixture = TestBed.createComponent(App);

--- a/ui/src/app/app.ts
+++ b/ui/src/app/app.ts
@@ -1203,7 +1203,9 @@ export class App implements AfterViewInit, OnInit, OnDestroy {
   buildDownloadLink(download: Download) {
     let baseDir = this.downloads.configuration["PUBLIC_HOST_URL"];
     if (download.download_type === 'audio' || download.filename.endsWith('.mp3')) {
-      baseDir = this.downloads.configuration["PUBLIC_HOST_AUDIO_URL"];
+      // Fall back to PUBLIC_HOST_URL when the audio host is blank, else the link goes root-relative and 404s.
+      baseDir = this.downloads.configuration["PUBLIC_HOST_AUDIO_URL"]
+        || this.downloads.configuration["PUBLIC_HOST_URL"];
     }
 
     if (download.folder) {
@@ -1299,7 +1301,9 @@ export class App implements AfterViewInit, OnInit, OnDestroy {
   buildChapterDownloadLink(download: Download, chapterFilename: string) {
     let baseDir = this.downloads.configuration["PUBLIC_HOST_URL"];
     if (download.download_type === 'audio' || chapterFilename.endsWith('.mp3')) {
-      baseDir = this.downloads.configuration["PUBLIC_HOST_AUDIO_URL"];
+      // Fall back to PUBLIC_HOST_URL when the audio host is blank (see buildDownloadLink).
+      baseDir = this.downloads.configuration["PUBLIC_HOST_AUDIO_URL"]
+        || this.downloads.configuration["PUBLIC_HOST_URL"];
     }
 
     if (download.folder) {


### PR DESCRIPTION
## The bug

When `PUBLIC_HOST_AUDIO_URL` is set but blank (for example `PUBLIC_HOST_AUDIO_URL=` left empty in a compose file), audio download links come out root-relative, like `app.url/song.mp3`, and 404. Video links keep working because they use `PUBLIC_HOST_URL`. So you end up with video downloads giving a working link and audio downloads giving a broken one.

## Why it happens

`os.environ.get(key, default)` only falls back to the default when the key is absent. A present-but-blank value stays `''`, and the trailing-slash normalizer skips empty strings, so `''` gets shipped to the browser. `buildDownloadLink` then uses that empty base with no fallback, and the link resolves against the page root.

## The fix

Backend: a blank `PUBLIC_HOST_AUDIO_URL` now inherits `PUBLIC_HOST_URL`, which is what the README already says it does ("Same as PUBLIC_HOST_URL but for audio downloads"). When both are blank it stays blank, so serving from the web root still works and the existing behavior is preserved.

Frontend: `buildDownloadLink` and `buildChapterDownloadLink` fall back to `PUBLIC_HOST_URL` when the audio host is blank, so an empty value can't produce a root-relative link even from the UI side.

## Known limit

If you run a separate `AUDIO_DOWNLOAD_DIR` and leave the audio host blank, inheriting `PUBLIC_HOST_URL` points audio at the video directory. That combination was already broken before this change, just root-relative instead. The answer there is to set `PUBLIC_HOST_AUDIO_URL` explicitly. I can add a directory-aware fallback if you'd prefer to cover it here.

## Tests

Added backend and UI regression tests, both confirmed to fail against the old code before the fix lands. Full backend suite passes (183), full UI suite passes (43), lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)