### PR TITLE
fix: fall back to a direct write when AtomicJsonStore.save cannot use a temp file (NFS EPERM)

### DIFF
--- a/app/state_store.py
+++ b/app/state_store.py
@@ -137,7 +137,7 @@ class AtomicJsonStore:
             with os.fdopen(fd, "w", encoding="utf-8") as f:
                 self._write_payload(payload, f)
                 f.flush()
-                os.fsync(f.fileno())
+                self._best_effort_fsync(f.fileno())
             os.replace(tmp_path, self.path)
             self._fsync_directory(parent)
         except Exception:
@@ -151,15 +151,20 @@ class AtomicJsonStore:
         with open(self.path, "w", encoding="utf-8") as f:
             self._write_payload(payload, f)
             f.flush()
-            try:
-                os.fsync(f.fileno())
-            except OSError as exc:
-                # Tolerate fsync being unsupported on the underlying filesystem
-                # (the same class of filesystem that forced this fallback), but
-                # let genuine storage failures such as ENOSPC/EIO surface rather
-                # than reporting a durable write that did not happen.
-                if exc.errno not in _ATOMIC_UNSUPPORTED_ERRNOS:
-                    raise
+            self._best_effort_fsync(f.fileno())
+
+    @staticmethod
+    def _best_effort_fsync(fileno: int) -> None:
+        # Tolerate fsync being unsupported on the underlying filesystem (for
+        # example a network mount that returns EINVAL/ENOSYS), but let genuine
+        # storage failures such as ENOSPC/EIO surface so a non-durable write is
+        # never reported as success. An unsupported fsync must not by itself
+        # abandon the atomic rename path.
+        try:
+            os.fsync(fileno)
+        except OSError as exc:
+            if exc.errno not in _ATOMIC_UNSUPPORTED_ERRNOS:
+                raise
 
     @staticmethod
     def _write_payload(payload: dict[str, Any], f: Any) -> None:

--- a/app/state_store.py
+++ b/app/state_store.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import collections.abc
+import errno
 import json
 import logging
 import os
@@ -16,6 +17,25 @@ log = logging.getLogger("state_store")
 STATE_SCHEMA_VERSION = 2
 _BYTES_MARKER = "__metube_bytes__"
 _DATETIME_MARKER = "__metube_datetime__"
+
+# Errnos that signal the filesystem cannot support the temp-file + rename
+# atomic-write strategy (for example an NFS-backed state dir returning EPERM on
+# mkstemp). These are safe to fall back on because they mean the atomic
+# mechanism is unavailable, not that the data write itself failed. Errors like
+# ENOSPC/EIO are deliberately excluded so a genuine storage failure surfaces
+# instead of silently truncating an existing good state file.
+_ATOMIC_UNSUPPORTED_ERRNOS = frozenset(
+    e
+    for e in (
+        errno.EPERM,
+        errno.EACCES,
+        errno.ENOSYS,
+        errno.EINVAL,
+        getattr(errno, "EOPNOTSUPP", None),
+        getattr(errno, "ENOTSUP", None),
+    )
+    if e is not None
+)
 
 
 def to_json_compatible(value: Any) -> Any:
@@ -100,6 +120,8 @@ class AtomicJsonStore:
         try:
             self._atomic_write(payload)
         except OSError as exc:
+            if exc.errno not in _ATOMIC_UNSUPPORTED_ERRNOS:
+                raise
             self._warn_direct_write_fallback(exc)
             self._direct_write(payload)
 

--- a/app/state_store.py
+++ b/app/state_store.py
@@ -148,7 +148,11 @@ class AtomicJsonStore:
             raise
 
     def _direct_write(self, payload: dict[str, Any]) -> None:
-        with open(self.path, "w", encoding="utf-8") as f:
+        # Create with 0o600 so the fallback keeps the owner-only permissions the
+        # atomic path gets from mkstemp; state files can contain URLs and
+        # per-download option overrides that must not leak on shared mounts.
+        fd = os.open(self.path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
             self._write_payload(payload, f)
             f.flush()
             self._best_effort_fsync(f.fileno())

--- a/app/state_store.py
+++ b/app/state_store.py
@@ -126,6 +126,7 @@ class AtomicJsonStore:
             self._direct_write(payload)
 
     def _atomic_write(self, payload: dict[str, Any]) -> None:
+        text = self._serialize(payload)
         parent = os.path.dirname(self.path) or "."
         fd, tmp_path = tempfile.mkstemp(
             prefix=f".{os.path.basename(self.path)}.",
@@ -135,7 +136,7 @@ class AtomicJsonStore:
         )
         try:
             with os.fdopen(fd, "w", encoding="utf-8") as f:
-                self._write_payload(payload, f)
+                f.write(text)
                 f.flush()
                 self._best_effort_fsync(f.fileno())
             os.replace(tmp_path, self.path)
@@ -148,6 +149,10 @@ class AtomicJsonStore:
             raise
 
     def _direct_write(self, payload: dict[str, Any]) -> None:
+        # Serialize before truncating so a serialization failure never destroys
+        # the existing state file (the atomic path gets this for free via its
+        # temp file).
+        text = self._serialize(payload)
         # Create with 0o600 so the fallback keeps the owner-only permissions the
         # atomic path gets from mkstemp; state files can contain URLs and
         # per-download option overrides that must not leak on shared mounts.
@@ -161,7 +166,7 @@ class AtomicJsonStore:
                 os.fchmod(f.fileno(), 0o600)
             except OSError:
                 pass
-            self._write_payload(payload, f)
+            f.write(text)
             f.flush()
             self._best_effort_fsync(f.fileno())
 
@@ -179,9 +184,8 @@ class AtomicJsonStore:
                 raise
 
     @staticmethod
-    def _write_payload(payload: dict[str, Any], f: Any) -> None:
-        json.dump(payload, f, ensure_ascii=False, separators=(",", ":"))
-        f.write("\n")
+    def _serialize(payload: dict[str, Any]) -> str:
+        return json.dumps(payload, ensure_ascii=False, separators=(",", ":")) + "\n"
 
     def _warn_direct_write_fallback(self, exc: OSError) -> None:
         if self._direct_write_fallback_warned:

--- a/app/state_store.py
+++ b/app/state_store.py
@@ -153,8 +153,13 @@ class AtomicJsonStore:
             f.flush()
             try:
                 os.fsync(f.fileno())
-            except OSError:
-                pass
+            except OSError as exc:
+                # Tolerate fsync being unsupported on the underlying filesystem
+                # (the same class of filesystem that forced this fallback), but
+                # let genuine storage failures such as ENOSPC/EIO surface rather
+                # than reporting a durable write that did not happen.
+                if exc.errno not in _ATOMIC_UNSUPPORTED_ERRNOS:
+                    raise
 
     @staticmethod
     def _write_payload(payload: dict[str, Any], f: Any) -> None:

--- a/app/state_store.py
+++ b/app/state_store.py
@@ -169,6 +169,8 @@ class AtomicJsonStore:
             f.write(text)
             f.flush()
             self._best_effort_fsync(f.fileno())
+        # Make the new directory entry durable too, matching the atomic path.
+        self._fsync_directory(os.path.dirname(self.path) or ".")
 
     @staticmethod
     def _best_effort_fsync(fileno: int) -> None:

--- a/app/state_store.py
+++ b/app/state_store.py
@@ -62,6 +62,7 @@ class AtomicJsonStore:
         self.path = path
         self.kind = kind
         self.schema_version = schema_version
+        self._direct_write_fallback_warned = False
 
     def _ensure_parent(self) -> None:
         parent = os.path.dirname(self.path)
@@ -96,6 +97,13 @@ class AtomicJsonStore:
     def save(self, data: dict[str, Any]) -> None:
         self._ensure_parent()
         payload = self._build_payload(data)
+        try:
+            self._atomic_write(payload)
+        except OSError as exc:
+            self._warn_direct_write_fallback(exc)
+            self._direct_write(payload)
+
+    def _atomic_write(self, payload: dict[str, Any]) -> None:
         parent = os.path.dirname(self.path) or "."
         fd, tmp_path = tempfile.mkstemp(
             prefix=f".{os.path.basename(self.path)}.",
@@ -105,8 +113,7 @@ class AtomicJsonStore:
         )
         try:
             with os.fdopen(fd, "w", encoding="utf-8") as f:
-                json.dump(payload, f, ensure_ascii=False, separators=(",", ":"))
-                f.write("\n")
+                self._write_payload(payload, f)
                 f.flush()
                 os.fsync(f.fileno())
             os.replace(tmp_path, self.path)
@@ -117,6 +124,30 @@ class AtomicJsonStore:
             except OSError:
                 pass
             raise
+
+    def _direct_write(self, payload: dict[str, Any]) -> None:
+        with open(self.path, "w", encoding="utf-8") as f:
+            self._write_payload(payload, f)
+            f.flush()
+            try:
+                os.fsync(f.fileno())
+            except OSError:
+                pass
+
+    @staticmethod
+    def _write_payload(payload: dict[str, Any], f: Any) -> None:
+        json.dump(payload, f, ensure_ascii=False, separators=(",", ":"))
+        f.write("\n")
+
+    def _warn_direct_write_fallback(self, exc: OSError) -> None:
+        if self._direct_write_fallback_warned:
+            return
+        self._direct_write_fallback_warned = True
+        log.warning(
+            "Atomic state write failed for %s (%s); falling back to direct write",
+            self.path,
+            exc,
+        )
 
     def quarantine_invalid_file(self, exc: Exception) -> None:
         if not os.path.exists(self.path):

--- a/app/state_store.py
+++ b/app/state_store.py
@@ -153,6 +153,14 @@ class AtomicJsonStore:
         # per-download option overrides that must not leak on shared mounts.
         fd = os.open(self.path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
         with os.fdopen(fd, "w", encoding="utf-8") as f:
+            # The 0o600 mode above only applies when the file is created; force
+            # it on rewrites too so an existing, broadly-permissioned state file
+            # is tightened to match the atomic path. Best-effort because some
+            # network filesystems reject chmod, and that must not re-crash save.
+            try:
+                os.fchmod(f.fileno(), 0o600)
+            except OSError:
+                pass
             self._write_payload(payload, f)
             f.flush()
             self._best_effort_fsync(f.fileno())

--- a/app/tests/test_state_store.py
+++ b/app/tests/test_state_store.py
@@ -4,6 +4,7 @@ import os
 import tempfile
 import unittest
 from datetime import datetime
+from unittest.mock import patch
 
 from state_store import AtomicJsonStore, from_json_compatible, to_json_compatible
 
@@ -20,6 +21,55 @@ class StateStoreTests(unittest.TestCase):
             self.assertEqual(payload["kind"], "persistent_queue:queue")
             self.assertEqual(payload["schema_version"], 2)
             self.assertEqual(payload["items"][0]["info"]["title"], "hello")
+
+    def test_save_falls_back_to_direct_write_when_mkstemp_fails(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "queue.json")
+            store = AtomicJsonStore(path, kind="persistent_queue:queue")
+
+            with self.assertLogs("state_store", level="WARNING") as logs:
+                with patch(
+                    "state_store.tempfile.mkstemp",
+                    side_effect=PermissionError(1, "Operation not permitted"),
+                ):
+                    store.save({"items": [{"key": "a"}]})
+
+            self.assertTrue(os.path.exists(path))
+            self.assertTrue(any(path in message for message in logs.output))
+            payload = store.load()
+            self.assertEqual(payload["items"], [{"key": "a"}])
+
+    def test_save_falls_back_to_direct_write_when_replace_fails(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "queue.json")
+            store = AtomicJsonStore(path, kind="persistent_queue:queue")
+
+            with patch(
+                "state_store.os.replace",
+                side_effect=PermissionError(1, "Operation not permitted"),
+            ):
+                store.save({"items": [{"key": "a"}]})
+
+            self.assertTrue(os.path.exists(path))
+            payload = store.load()
+            self.assertEqual(payload["items"], [{"key": "a"}])
+            self.assertEqual([], [name for name in os.listdir(tmp) if name.endswith(".tmp")])
+
+    def test_save_reraises_when_atomic_and_direct_write_fail(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "queue.json")
+            store = AtomicJsonStore(path, kind="persistent_queue:queue")
+
+            with patch(
+                "state_store.tempfile.mkstemp",
+                side_effect=PermissionError(1, "Operation not permitted"),
+            ):
+                with patch("builtins.open", side_effect=PermissionError(13, "Permission denied")):
+                    with self.assertRaises(PermissionError) as ctx:
+                        store.save({"items": [{"key": "a"}]})
+
+            self.assertEqual(ctx.exception.errno, 13)
+            self.assertFalse(os.path.exists(path))
 
     def test_invalid_file_is_quarantined(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/app/tests/test_state_store.py
+++ b/app/tests/test_state_store.py
@@ -41,6 +41,23 @@ class StateStoreTests(unittest.TestCase):
             payload = store.load()
             self.assertEqual(payload["items"], [{"key": "a"}])
 
+    def test_fallback_tightens_permissions_on_existing_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "queue.json")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write("{}")
+            os.chmod(path, 0o644)
+
+            store = AtomicJsonStore(path, kind="persistent_queue:queue")
+            with patch(
+                "state_store.tempfile.mkstemp",
+                side_effect=PermissionError(1, "Operation not permitted"),
+            ):
+                store.save({"items": [{"key": "a"}]})
+
+            self.assertEqual(os.stat(path).st_mode & 0o777, 0o600)
+            self.assertEqual(store.load()["items"], [{"key": "a"}])
+
     def test_save_falls_back_to_direct_write_when_replace_fails(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = os.path.join(tmp, "queue.json")

--- a/app/tests/test_state_store.py
+++ b/app/tests/test_state_store.py
@@ -71,6 +71,28 @@ class StateStoreTests(unittest.TestCase):
             self.assertEqual(ctx.exception.errno, 13)
             self.assertFalse(os.path.exists(path))
 
+    def test_save_reraises_and_preserves_state_on_non_atomic_errno(self):
+        # A storage failure such as ENOSPC is not an "atomic unavailable"
+        # signal, so it must surface instead of falling back to a direct write
+        # that would truncate the existing good state file.
+        import errno as _errno
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "queue.json")
+            store = AtomicJsonStore(path, kind="persistent_queue:queue")
+            store.save({"items": [{"key": "good"}]})
+
+            with patch(
+                "state_store.tempfile.mkstemp",
+                side_effect=OSError(_errno.ENOSPC, "No space left on device"),
+            ):
+                with self.assertRaises(OSError) as ctx:
+                    store.save({"items": [{"key": "new"}]})
+
+            self.assertEqual(ctx.exception.errno, _errno.ENOSPC)
+            # Existing state is untouched.
+            self.assertEqual(store.load()["items"], [{"key": "good"}])
+
     def test_invalid_file_is_quarantined(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = os.path.join(tmp, "queue.json")

--- a/app/tests/test_state_store.py
+++ b/app/tests/test_state_store.py
@@ -36,6 +36,8 @@ class StateStoreTests(unittest.TestCase):
 
             self.assertTrue(os.path.exists(path))
             self.assertTrue(any(path in message for message in logs.output))
+            # Fallback keeps owner-only permissions, matching the atomic path.
+            self.assertEqual(os.stat(path).st_mode & 0o777, 0o600)
             payload = store.load()
             self.assertEqual(payload["items"], [{"key": "a"}])
 
@@ -64,7 +66,10 @@ class StateStoreTests(unittest.TestCase):
                 "state_store.tempfile.mkstemp",
                 side_effect=PermissionError(1, "Operation not permitted"),
             ):
-                with patch("builtins.open", side_effect=PermissionError(13, "Permission denied")):
+                with patch(
+                    "state_store.os.open",
+                    side_effect=PermissionError(13, "Permission denied"),
+                ):
                     with self.assertRaises(PermissionError) as ctx:
                         store.save({"items": [{"key": "a"}]})
 

--- a/app/tests/test_state_store.py
+++ b/app/tests/test_state_store.py
@@ -134,6 +134,23 @@ class StateStoreTests(unittest.TestCase):
             # Existing state is untouched.
             self.assertEqual(store.load()["items"], [{"key": "good"}])
 
+    def test_serialization_failure_preserves_existing_state(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "queue.json")
+            store = AtomicJsonStore(path, kind="persistent_queue:queue")
+            store.save({"items": [{"key": "good"}]})
+
+            # Even on the fallback path, a non-serializable payload must raise
+            # before the existing good state file is touched.
+            with patch(
+                "state_store.tempfile.mkstemp",
+                side_effect=PermissionError(1, "Operation not permitted"),
+            ):
+                with self.assertRaises(TypeError):
+                    store.save({"items": object()})
+
+            self.assertEqual(store.load()["items"], [{"key": "good"}])
+
     def test_invalid_file_is_quarantined(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = os.path.join(tmp, "queue.json")

--- a/app/tests/test_state_store.py
+++ b/app/tests/test_state_store.py
@@ -71,6 +71,25 @@ class StateStoreTests(unittest.TestCase):
             self.assertEqual(ctx.exception.errno, 13)
             self.assertFalse(os.path.exists(path))
 
+    def test_unsupported_fsync_keeps_atomic_path(self):
+        # fsync being unsupported (EINVAL/ENOSYS) must not by itself trigger the
+        # direct-write fallback; the atomic temp-file + rename path still runs.
+        import errno as _errno
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "queue.json")
+            store = AtomicJsonStore(path, kind="persistent_queue:queue")
+
+            with patch(
+                "state_store.os.fsync",
+                side_effect=OSError(_errno.EINVAL, "Invalid argument"),
+            ):
+                with self.assertNoLogs("state_store", level="WARNING"):
+                    store.save({"items": [{"key": "a"}]})
+
+            self.assertEqual(store.load()["items"], [{"key": "a"}])
+            self.assertEqual([], [name for name in os.listdir(tmp) if name.endswith(".tmp")])
+
     def test_save_reraises_and_preserves_state_on_non_atomic_errno(self):
         # A storage failure such as ENOSPC is not an "atomic unavailable"
         # signal, so it must surface instead of falling back to a direct write


### PR DESCRIPTION
## Summary

MeTube no longer crashes on every download enqueue when its state directory lives on an NFS mount. `AtomicJsonStore.save` now keeps its atomic temp-file + rename path as the default, and only when that path reports the filesystem cannot support it (EPERM/EACCES/ENOSYS/EINVAL and similar) does it fall back to writing the state file directly.

## Why this matters

Reported in #960: after upgrading, adding any download fails with `PermissionError: [Errno 1] Operation not permitted: '/downloads/.metube/.queue.json.<rand>.tmp'`, ending in `state_store.py` at the `tempfile.mkstemp(...)` call. The reporter's state directory is on an NFS mount where the MeTube user owns `.metube` and can create and populate files, yet `mkstemp` returns EPERM. Because `save` runs on the hot path of every enqueue/start/complete transition, the crash is fatal for every download. Pinning back to `2025.12.27`, which persisted state with a plain direct write, makes downloads work again, so this is a regression introduced by the `AtomicJsonStore` persistence layer.

The fix restores that direct-write behavior only as a fallback. POSIX filesystems keep the atomic guarantee; NFS-style mounts that reject the temp-file dance get a direct write, which is exactly what the working release did and what the reporter confirmed the mount allows.

The fallback is deliberately narrow so it does not mask real problems:

- It triggers only for errnos that mean the atomic mechanism is unavailable. Genuine storage errors such as ENOSPC/EIO still propagate instead of silently truncating a good state file.
- The payload is serialized before the file is opened, so a serialization error never destroys existing state.
- The fallback file is created (and rewrites are chmodded) to `0600`, matching the owner-only permissions `mkstemp` gives, so state that can contain URLs and per-download option overrides is not exposed on shared mounts.
- `fsync` is best-effort for filesystems that do not support it, but real fsync storage errors still surface, and the parent directory is fsynced for durability parity with the atomic path.

All persistence flows through this one method, so the fix covers the queue and subscription state surfaces without touching `ytdl.py` or `subscriptions.py`.

## Testing

- `python -m pytest app/tests/test_state_store.py` (new tests): fallback persists state when `mkstemp` raises EPERM; fallback persists state and leaves no stray temp file when `os.replace` raises EPERM; an unsupported `fsync` keeps the atomic path rather than falling back; a non-atomic errno (ENOSPC) re-raises without truncating existing state; both paths failing re-raises; a serialization failure preserves existing state; the fallback creates the file `0600` and tightens an existing `0644` file to `0600`; plus the existing round-trip, quarantine, and bytes/datetime compat tests.
- `python -m pytest app/tests/test_state_store.py app/tests/test_persistent_queue.py app/tests/test_subscriptions.py` all pass (45 tests).
- `python -m compileall app` passes.

Fixes #960
