### PR TITLE
Don't mark a subscription as broken just because all entries are filtered out as they have already been downloaded

### DIFF
--- a/app/subscriptions.py
+++ b/app/subscriptions.py
@@ -717,7 +717,7 @@ class SubscriptionManager:
         entries = [ent for ent in entries if _is_media_entry(ent)]
 
         etype = (info or {}).get("_type") or "video"
-        if etype == "video" or not entries:
+        if etype == "video":
             async with self._lock:
                 cur = self._subs.get(sid)
                 if cur:
@@ -730,6 +730,22 @@ class SubscriptionManager:
                         raise
                     sub = cur
             log.warning("Subscription %s no longer resolves to a subscribable feed", sub.name)
+            await self.notifier.subscription_updated(sub)
+            return
+        if not entries:
+            async with self._lock:
+                cur = self._subs.get(sid)
+                if cur:
+                    previous = copy.deepcopy(cur)
+                    cur.last_checked = time.time()
+                    cur.error = None
+                    try:
+                        self._save_locked()
+                    except Exception:
+                        self._subs[sid] = previous
+                        raise
+                    sub = cur
+            log.warning("Subscription check finished for %s: No entries found", sub.name)
             await self.notifier.subscription_updated(sub)
             return
 


### PR DESCRIPTION
This happens e.g. if `download_archive` is used and SUBSCRIPTION_SCAN_PLAYLIST_END is too small and new entries are added to the end instead of the beginning of the playlist leading to a super confusing error message at the moment (_"This URL points to a single video, not a channel or playlist. Use Download instead."_).