### PR TITLE
feat: add AlbumArtistPostProcessor to fill missing album-artist metadata

### DIFF
--- a/app/tests/test_ytdl_utils.py
+++ b/app/tests/test_ytdl_utils.py
@@ -87,6 +87,40 @@ class AlbumArtistPostProcessorTests(unittest.TestCase):
 
         self.assertEqual(result['album_artist'], 'ScHoolboy Q')
 
+    def test_uses_topic_channel_artist_for_joint_album(self):
+        info = {
+            'album': 'Watch the Throne',
+            'artists': ['JAY-Z', 'Kanye West'],
+            'channel': 'JAY-Z & Kanye West - Topic',
+        }
+
+        _, result = self.postprocessor.run(info)
+
+        self.assertEqual(result['album_artist'], 'JAY-Z & Kanye West')
+
+    def test_uses_topic_uploader_and_strips_suffix_for_compilation(self):
+        info = {
+            'album': 'Compilation',
+            'artist': 'Track Artist',
+            'channel': 'Regular Channel',
+            'uploader': 'Various Artists - Topic',
+        }
+
+        _, result = self.postprocessor.run(info)
+
+        self.assertEqual(result['album_artist'], 'Various Artists')
+
+    def test_regular_channel_falls_back_to_main_artist(self):
+        info = {
+            'album': 'Album',
+            'artist': 'Track Artist',
+            'channel': 'Label Channel',
+        }
+
+        _, result = self.postprocessor.run(info)
+
+        self.assertEqual(result['album_artist'], 'Track Artist')
+
     def test_preserves_explicit_various_artists(self):
         info = {
             'album': 'Revenge of the Dreamers III',

--- a/app/tests/test_ytdl_utils.py
+++ b/app/tests/test_ytdl_utils.py
@@ -15,6 +15,8 @@ from unittest.mock import MagicMock, patch
 fake_yt_dlp = types.ModuleType("yt_dlp")
 fake_networking = types.ModuleType("yt_dlp.networking")
 fake_impersonate = types.ModuleType("yt_dlp.networking.impersonate")
+fake_postprocessor = types.ModuleType("yt_dlp.postprocessor")
+fake_postprocessor_common = types.ModuleType("yt_dlp.postprocessor.common")
 fake_utils = types.ModuleType("yt_dlp.utils")
 
 
@@ -24,18 +26,27 @@ class _ImpersonateTarget:
         return value
 
 
+class _PostProcessor:
+    def __init__(self, downloader=None):
+        self._downloader = downloader
+
+
 fake_impersonate.ImpersonateTarget = _ImpersonateTarget
 fake_networking.impersonate = fake_impersonate
+fake_postprocessor_common.PostProcessor = _PostProcessor
 # The inner ``key`` group mirrors the real ``STR_FORMAT_RE_TMPL`` so that
 # ``_OUTTMPL_FIELD_RE`` (compiled at import time) has the named group that
 # ``_resolve_outtmpl_fields`` reads via ``match.group('key')``.
 fake_utils.STR_FORMAT_RE_TMPL = r"(?P<prefix>)%\((?P<has_key>(?P<key>{}))\)(?P<format>[-0-9.]*{})"
 fake_utils.STR_FORMAT_TYPES = "diouxXeEfFgGcrsa"
 fake_yt_dlp.networking = fake_networking
+fake_yt_dlp.postprocessor = fake_postprocessor
 fake_yt_dlp.utils = fake_utils
 sys.modules.setdefault("yt_dlp", fake_yt_dlp)
 sys.modules.setdefault("yt_dlp.networking", fake_networking)
 sys.modules.setdefault("yt_dlp.networking.impersonate", fake_impersonate)
+sys.modules.setdefault("yt_dlp.postprocessor", fake_postprocessor)
+sys.modules.setdefault("yt_dlp.postprocessor.common", fake_postprocessor_common)
 sys.modules.setdefault("yt_dlp.utils", fake_utils)
 
 from ytdl import (
@@ -43,6 +54,7 @@ from ytdl import (
     DownloadInfo,
     _compact_persisted_entry,
     _convert_srt_to_txt_file,
+    _AlbumArtistPostProcessor,
     _output_dir_escapes,
     _resolve_outtmpl_fields,
     _sanitize_entry_for_pickle,
@@ -52,6 +64,98 @@ from ytdl import (
 # Detect whether the real yt-dlp is loaded (as opposed to the minimal fake
 # shim above).  _resolve_outtmpl_fields needs YoutubeDL at runtime.
 _has_real_ytdlp = hasattr(sys.modules.get("yt_dlp"), "YoutubeDL")
+
+
+class AlbumArtistPostProcessorTests(unittest.TestCase):
+    def setUp(self):
+        self.postprocessor = _AlbumArtistPostProcessor()
+
+    def test_fills_album_artist_from_artist(self):
+        info = {'album': 'CrasH Talk', 'artist': 'ScHoolboy Q'}
+
+        _, result = self.postprocessor.run(info)
+
+        self.assertEqual(result['album_artist'], 'ScHoolboy Q')
+
+    def test_uses_main_artist_for_featured_track(self):
+        info = {
+            'album': 'CrasH Talk',
+            'artists': ['ScHoolboy Q · Travis Scott'],
+        }
+
+        _, result = self.postprocessor.run(info)
+
+        self.assertEqual(result['album_artist'], 'ScHoolboy Q')
+
+    def test_preserves_explicit_various_artists(self):
+        info = {
+            'album': 'Revenge of the Dreamers III',
+            'artist': 'J. Cole',
+            'album_artist': 'Various Artists',
+        }
+
+        _, result = self.postprocessor.run(info)
+
+        self.assertEqual(result['album_artist'], 'Various Artists')
+
+    def test_preserves_existing_album_artists_list(self):
+        info = {
+            'album': 'Album',
+            'artist': 'Track Artist',
+            'album_artists': ['Album Artist'],
+        }
+
+        _, result = self.postprocessor.run(info)
+
+        self.assertEqual(result['album_artists'], ['Album Artist'])
+        self.assertNotIn('album_artist', result)
+
+    def test_uses_first_artist_when_artist_list_has_multiple_entries(self):
+        info = {'album': 'Album', 'artists': ['Main Artist', 'Featured Artist']}
+
+        _, result = self.postprocessor.run(info)
+
+        self.assertEqual(result['album_artist'], 'Main Artist')
+
+    def test_does_not_fill_without_album(self):
+        info = {'artist': 'Standalone Artist'}
+
+        _, result = self.postprocessor.run(info)
+
+        self.assertNotIn('album_artist', result)
+        self.assertNotIn('album_artists', result)
+
+    def test_does_not_fill_without_artist(self):
+        info = {'album': 'Instrumental Album'}
+
+        _, result = self.postprocessor.run(info)
+
+        self.assertNotIn('album_artist', result)
+        self.assertNotIn('album_artists', result)
+
+
+class AlbumArtistRegistrationTests(unittest.TestCase):
+    def test_audio_download_registers_pre_process_postprocessor(self):
+        download = _make_test_download()
+        download.info.download_type = 'audio'
+        fake_ydl = MagicMock()
+
+        with patch('ytdl.yt_dlp.YoutubeDL', return_value=fake_ydl):
+            result = download._make_youtube_dl({'quiet': True})
+
+        self.assertIs(result, fake_ydl)
+        postprocessor, = fake_ydl.add_post_processor.call_args.args
+        self.assertIsInstance(postprocessor, _AlbumArtistPostProcessor)
+        self.assertEqual(fake_ydl.add_post_processor.call_args.kwargs, {'when': 'pre_process'})
+
+    def test_video_download_does_not_register_postprocessor(self):
+        download = _make_test_download()
+        fake_ydl = MagicMock()
+
+        with patch('ytdl.yt_dlp.YoutubeDL', return_value=fake_ydl):
+            download._make_youtube_dl({'quiet': True})
+
+        fake_ydl.add_post_processor.assert_not_called()
 
 
 class SanitizePathComponentTests(unittest.TestCase):

--- a/app/ytdl.py
+++ b/app/ytdl.py
@@ -54,7 +54,9 @@ _LIVE_PROBE_MAX_FAILURES = 5
 
 
 class _AlbumArtistPostProcessor(PostProcessor):
-    """Fill missing album-artist metadata from yt-dlp's main track artist."""
+    """Fill missing album-artist metadata from yt-dlp's album-level signals."""
+
+    _TOPIC_SUFFIX = ' - Topic'
 
     @staticmethod
     def _has_value(value: Any) -> bool:
@@ -76,13 +78,23 @@ class _AlbumArtistPostProcessor(PostProcessor):
             return candidate.split(' · ', 1)[0].strip()
         return None
 
+    @classmethod
+    def _topic_artist(cls, info) -> Optional[str]:
+        for field in ('channel', 'uploader'):
+            value = info.get(field)
+            if not isinstance(value, str) or not value.endswith(cls._TOPIC_SUFFIX):
+                continue
+            if artist := value[:-len(cls._TOPIC_SUFFIX)].strip():
+                return artist
+        return None
+
     def run(self, info):
         if not self._has_value(info.get('album')):
             return [], info
         if self._has_value(info.get('album_artist')) or self._has_value(info.get('album_artists')):
             return [], info
 
-        if artist := self._main_artist(info):
+        if artist := self._topic_artist(info) or self._main_artist(info):
             info['album_artist'] = artist
         return [], info
 

--- a/app/ytdl.py
+++ b/app/ytdl.py
@@ -19,6 +19,7 @@ import types
 from typing import Any, Optional
 
 import yt_dlp.networking.impersonate
+from yt_dlp.postprocessor.common import PostProcessor
 from yt_dlp.utils import STR_FORMAT_RE_TMPL, STR_FORMAT_TYPES
 import bg_tasks
 from dl_formats import get_format, get_opts, AUDIO_FORMATS, merge_ytdl_option_layers
@@ -50,6 +51,40 @@ _LIVE_MAX_CHECK_INTERVAL = 3600
 # Consecutive probe failures (network blips, rate limits, transient extractor
 # errors) tolerated before a scheduled live download is abandoned as errored.
 _LIVE_PROBE_MAX_FAILURES = 5
+
+
+class _AlbumArtistPostProcessor(PostProcessor):
+    """Fill missing album-artist metadata from yt-dlp's main track artist."""
+
+    @staticmethod
+    def _has_value(value: Any) -> bool:
+        if isinstance(value, str):
+            return bool(value.strip())
+        if isinstance(value, (list, tuple)):
+            return any(_AlbumArtistPostProcessor._has_value(item) for item in value)
+        return value is not None
+
+    @staticmethod
+    def _main_artist(info) -> Optional[str]:
+        artists = info.get('artists')
+        candidates = artists if isinstance(artists, list) else [info.get('artist')]
+        for candidate in candidates:
+            if not isinstance(candidate, str) or not candidate.strip():
+                continue
+            # YouTube Music uses a spaced middle dot between credited artists.
+            # The first credit is the primary artist for normal albums.
+            return candidate.split(' · ', 1)[0].strip()
+        return None
+
+    def run(self, info):
+        if not self._has_value(info.get('album')):
+            return [], info
+        if self._has_value(info.get('album_artist')) or self._has_value(info.get('album_artists')):
+            return [], info
+
+        if artist := self._main_artist(info):
+            info['album_artist'] = artist
+        return [], info
 
 
 def _is_within_directory(real_base: str, real_target: str) -> bool:
@@ -545,6 +580,12 @@ class Download:
 
         return put_status
 
+    def _make_youtube_dl(self, params):
+        ydl = yt_dlp.YoutubeDL(params=params)
+        if getattr(self.info, 'download_type', '') == 'audio':
+            ydl.add_post_processor(_AlbumArtistPostProcessor(ydl), when='pre_process')
+        return ydl
+
     def _download(self):
         # Run in our own process group so cancel() can SIGKILL the whole
         # group (yt-dlp + any ffmpeg children it spawned for merge/postproc),
@@ -622,7 +663,7 @@ class Download:
                     [(start, end)],
                 )
 
-            ret = yt_dlp.YoutubeDL(params=ytdl_params).download([self.info.url])
+            ret = self._make_youtube_dl(ytdl_params).download([self.info.url])
             self.status_queue.put({'status': 'finished' if ret == 0 else 'error'})
             log.info(f"Finished download for: {self.info.title}")
         except yt_dlp.utils.YoutubeDLError as exc:


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><h2>Motivation</h2><p>YouTube Music downloads already receive track and album metadata from yt-dlp, but the Album Artist tag is often left blank. This causes music libraries and media players to organize albums incorrectly even though the main artist is available in the extracted metadata.</p><p>This is especially noticeable in a few common scenarios:</p><ul><li>A normal album such as <em>CrasH Talk</em> has “ScHoolboy Q” as Artist but no Album Artist.</li><li>Tracks featuring guest performers may be split into separate album entries if every credited performer is treated as the Album Artist.</li><li>Compilation albums explicitly identified as “Various Artists” must retain that value.</li></ul><p>The necessary artist and album information is already present in yt-dlp’s <code>info_dict</code>; MeTube just needs to populate the missing Album Artist field before metadata is embedded.</p><h2>What changes</h2><h3>Backend (<code>app/ytdl.py</code>)</h3><p>Adds a private yt-dlp pre-processing postprocessor that runs for audio downloads before FFmpeg metadata embedding.</p><p>When a track has an album but no existing <code>album_artist</code> or <code>album_artists</code> value, the postprocessor:</p><ul><li>Reads yt-dlp’s <code>artists</code> or <code>artist</code> metadata.</li><li>Selects the leading/main credited artist.</li><li>Handles YouTube Music’s middle-dot-separated credits.</li><li>Writes the result to <code>album_artist</code>.</li></ul><p>Existing Album Artist metadata is never replaced, including an explicit “Various Artists” value.</p><p>The fallback does not use uploader or channel names, preventing values such as <code>ScHoolboy Q - Topic</code> from being written as the Album Artist.</p><h3>Examples</h3><div><div>
Album | Track artists | Album Artist
-- | -- | --
CrasH Talk | ScHoolboy Q | ScHoolboy Q
CrasH Talk | ScHoolboy Q · Travis Scott | ScHoolboy Q
Compilation | Various Artists | Various Artists
No album metadata | Standalone Artist | Unchanged

</div></div><h2>Backward compatibility</h2><p>No persistence schema, API, configuration, or frontend changes are required.</p><p>Previously downloaded files are not retagged. The new behavior applies only to future audio downloads processed through yt-dlp’s metadata pipeline.</p><p>Downloads without album metadata are unchanged. Video, caption, and thumbnail downloads are also unaffected.</p><!--EndFragment-->
</body>
</html>