### PR TITLE
feat: music metadata lookup and tagging for finished audio downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Key capabilities:
 * Download videos, audio, captions, and thumbnails from a browser UI.
 * Download playlists and channels, with configurable output and download options.
 * Subscribe to channels and playlists, periodically check for new items, and queue new uploads automatically.
+* Tag finished audio downloads with song metadata (looked up on iTunes/Deezer) and optionally file them into Artist/Album folders.
 
 ![screenshot1](https://github.com/alexta69/metube/raw/master/screenshot.gif)
 

--- a/app/main.py
+++ b/app/main.py
@@ -21,6 +21,7 @@ from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 from watchfiles import DefaultFilter, Change, awatch
 
 import bg_tasks
+import music_meta
 from ytdl import DownloadQueueNotifier, DownloadQueue, Download
 from subscriptions import SubscriptionManager, SubscriptionNotifier, SubscriptionInfo, coerce_optional_bool
 from yt_dlp.version import __version__ as yt_dlp_version
@@ -1103,6 +1104,41 @@ async def history(request):
     log.info("Sending download history")
     return web.Response(text=serializer.encode(history))
 
+@routes.get(config.URL_PREFIX + 'music-meta')
+async def music_meta_search(request):
+    query = request.query.get('q', '').strip()[:200]
+    if not query:
+        raise web.HTTPBadRequest(reason="missing 'q'")
+    try:
+        candidates = await music_meta.search_candidates(query)
+    except Exception as e:
+        log.warning(f'music metadata lookup failed: {e!r}')
+        raise web.HTTPBadGateway(reason='metadata lookup failed')
+    return web.Response(text=serializer.encode({'status': 'ok', 'candidates': candidates}))
+
+@routes.get(config.URL_PREFIX + 'music-meta/source')
+async def music_meta_source(request):
+    id = request.query.get('id')
+    if not id:
+        raise web.HTTPBadRequest(reason="missing 'id'")
+    return web.Response(text=serializer.encode(dqueue.music_source(id)))
+
+@routes.post(config.URL_PREFIX + 'music-tag')
+async def music_tag(request):
+    post = await _read_json_request(request)
+    id = post.get('id')
+    title = str(post.get('title') or '').strip()
+    if not id or not title:
+        raise web.HTTPBadRequest(reason="missing 'id' or 'title'")
+    artists = [str(a).strip() for a in (post.get('artists') or []) if str(a).strip()]
+    genres = [str(g).strip() for g in (post.get('genres') or []) if str(g).strip()]
+    album = str(post.get('album') or '').strip() or title
+    date = str(post.get('date') or '').strip()[:10] or None
+    organize = bool(post.get('organize'))
+    status = await dqueue.music_tag(id, title, artists, album, date, genres, organize)
+    log.info(f"Music tag request processed for id: {id}, organize: {organize}")
+    return web.Response(text=serializer.encode(status))
+
 @sio.event
 async def connect(sid, environ):
     log.info(f"Client connected: {sid}")
@@ -1235,6 +1271,7 @@ app.router.add_route('OPTIONS', config.URL_PREFIX + 'subscriptions', add_cors)
 app.router.add_route('OPTIONS', config.URL_PREFIX + 'subscriptions/update', add_cors)
 app.router.add_route('OPTIONS', config.URL_PREFIX + 'subscriptions/delete', add_cors)
 app.router.add_route('OPTIONS', config.URL_PREFIX + 'subscriptions/check', add_cors)
+app.router.add_route('OPTIONS', config.URL_PREFIX + 'music-tag', add_cors)
 app.router.add_route('OPTIONS', config.URL_PREFIX + 'upload-cookies', add_cors)
 app.router.add_route('OPTIONS', config.URL_PREFIX + 'delete-cookies', add_cors)
 

--- a/app/music_meta.py
+++ b/app/music_meta.py
@@ -1,0 +1,181 @@
+"""Music metadata helpers: song lookups against public music databases and
+audio-file tagging via mutagen.
+
+Used by the music-tag feature: finished audio downloads can be tagged with
+proper song metadata (title / artists / album / date / genres) and optionally
+filed into an Artist/Album directory layout inside the audio download dir.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import re
+from urllib.parse import quote
+
+import aiohttp
+from mutagen import File as MutagenFile
+
+log = logging.getLogger('music_meta')
+
+# Extensions mutagen can reliably retag in place.
+TAGGABLE_EXTS = {'.mp3', '.m4a', '.aac', '.opus', '.ogg', '.oga', '.flac', '.wav', '.wv', '.aif', '.aiff'}
+
+LOOKUP_TIMEOUT = aiohttp.ClientTimeout(total=8)
+USER_AGENT = 'metube (https://github.com/alexta69/metube)'
+
+
+def split_artists(s):
+    """Split a database artist string: "A & B feat. C" -> ['A', 'B', 'C'].
+
+    Only for database-provided strings — user-typed fields go through
+    split_list, where '&' must survive ("Hootie & the Blowfish", "R&B").
+    """
+    parts = re.split(r'\s*[,&;]\s*|\s+(?:featuring|feat\.?|ft\.?)\s+', str(s or ''), flags=re.IGNORECASE)
+    return [p.strip() for p in parts if p and p.strip()]
+
+
+def split_list(s):
+    """Split a user-typed comma/semicolon-separated list."""
+    return [p.strip() for p in re.split(r'\s*[,;]\s*', str(s or '')) if p.strip()]
+
+
+def sanitize_part(name, fallback):
+    """A path component safe on every filesystem, or the fallback."""
+    cleaned = re.sub(r'[<>:"/\\|?*\x00-\x1f]+', ' ', str(name or ''))
+    cleaned = re.sub(r'\s+', ' ', cleaned).strip().strip('.')[:80].strip()
+    return cleaned or fallback
+
+
+async def _fetch_json(session, url):
+    async with session.get(url, headers={'User-Agent': USER_AGENT}) as resp:
+        if resp.status != 200:
+            raise RuntimeError(f'upstream {resp.status}')
+        # Deezer serves JSON with a text/html content type on some endpoints.
+        return json.loads(await resp.text())
+
+
+async def search_candidates(query):
+    """Song candidates for a free-text query from iTunes Search and Deezer
+    (both keyless). Returns up to 10 dicts: {source, title, artists[], album,
+    date, genres[], cover}. Either provider failing alone is fine.
+    """
+    out = []
+    seen = set()
+
+    def push(candidate):
+        key = (','.join(candidate['artists']) + '|' + (candidate['title'] or '')).lower()
+        if candidate['title'] and candidate['artists'] and key not in seen:
+            seen.add(key)
+            out.append(candidate)
+
+    async with aiohttp.ClientSession(timeout=LOOKUP_TIMEOUT) as session:
+        itunes, deezer = await asyncio.gather(
+            _fetch_json(session, f'https://itunes.apple.com/search?media=music&entity=song&limit=6&term={quote(query)}'),
+            _fetch_json(session, f'https://api.deezer.com/search?limit=4&q={quote(query)}'),
+            return_exceptions=True,
+        )
+
+        if not isinstance(itunes, BaseException):
+            for row in itunes.get('results') or []:
+                push({
+                    'source': 'itunes',
+                    'title': row.get('trackName'),
+                    'artists': split_artists(row.get('artistName')),
+                    'album': row.get('collectionName'),
+                    'date': str(row.get('releaseDate'))[:10] if row.get('releaseDate') else None,
+                    'genres': [row['primaryGenreName']] if row.get('primaryGenreName') else [],
+                    'cover': row.get('artworkUrl100'),
+                })
+        else:
+            log.info(f'iTunes lookup failed: {itunes}')
+
+        if not isinstance(deezer, BaseException):
+            rows = deezer.get('data') or []
+            # Deezer's search rows lack date/genres; the album lookup has both.
+            albums = await asyncio.gather(
+                *[
+                    _fetch_json(session, f'https://api.deezer.com/album/{row["album"]["id"]}')
+                    if row.get('album', {}).get('id') else _fail('no album')
+                    for row in rows
+                ],
+                return_exceptions=True,
+            )
+            for row, album in zip(rows, albums):
+                album = None if isinstance(album, BaseException) else album
+                genres = []
+                if album and isinstance(album.get('genres', {}).get('data'), list):
+                    genres = [g.get('name') for g in album['genres']['data'] if g.get('name')]
+                push({
+                    'source': 'deezer',
+                    'title': row.get('title'),
+                    'artists': split_artists((row.get('artist') or {}).get('name')),
+                    'album': (row.get('album') or {}).get('title'),
+                    'date': (album or {}).get('release_date'),
+                    'genres': genres,
+                    'cover': (row.get('album') or {}).get('cover_medium'),
+                })
+        else:
+            log.info(f'Deezer lookup failed: {deezer}')
+
+    return out[:10]
+
+
+async def _fail(msg):
+    raise RuntimeError(msg)
+
+
+def tag_audio_file(path, tags):
+    """Rewrite the tags of an audio file in place via mutagen. Values: string,
+    list (multi-value tag), '' / [] (clears the field) or None (leaves it
+    alone). Mutagen edits tags without remuxing, so embedded cover art
+    survives — ffmpeg's ogg muxer would drop it.
+    """
+    audio = MutagenFile(path, easy=True)
+    if audio is None:
+        raise ValueError('unsupported audio file')
+    for key, value in tags.items():
+        if value is None:
+            continue
+        try:
+            if value == '' or value == []:
+                if key in audio:
+                    del audio[key]
+            else:
+                audio[key] = value
+        except Exception:
+            # Not every tag key exists in every container; skip what doesn't fit.
+            pass
+    audio.save()
+
+
+def build_tags(title, artists, album, date, genres):
+    """The tag dict for a song: the given fields plus clearing of the
+    video-site leftovers (description, watch links) that yt-dlp's
+    --embed-metadata writes — junk in a music library.
+    """
+    return {
+        'title': title,
+        'artist': artists,
+        'albumartist': artists[0] if artists else None,
+        'album': album,
+        'date': date,
+        'genre': genres,
+        'synopsis': '',
+        'description': '',
+        'comment': '',
+        'purl': '',
+    }
+
+
+def organized_rel_path(artists, album, date, title, ext):
+    """Library layout: Artist/Album(Year)/Artist - Album(Year) - Title.ext.
+
+    Artist + album repeat in the file name on purpose: the file stays
+    traceable even when it ends up outside its folder.
+    """
+    year = str(date)[:4] if date else None
+    artist_dir = sanitize_part(artists[0] if artists else None, 'Unknown Artist')
+    album_dir = sanitize_part(album, 'Unknown Album') + (f'({year})' if year else '')
+    file_name = f'{artist_dir} - {album_dir} - {sanitize_part(title, "Unknown")}{ext}'
+    return os.path.join(artist_dir, album_dir, file_name)

--- a/app/tests/test_music_meta.py
+++ b/app/tests/test_music_meta.py
@@ -1,0 +1,83 @@
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+import music_meta
+
+
+class SplitArtistsTests(unittest.TestCase):
+    def test_splits_database_separators(self):
+        self.assertEqual(music_meta.split_artists('A & B feat. C'), ['A', 'B', 'C'])
+        self.assertEqual(music_meta.split_artists('X, Y; Z'), ['X', 'Y', 'Z'])
+        self.assertEqual(music_meta.split_artists('Solo ft. Guest'), ['Solo', 'Guest'])
+
+    def test_handles_empty(self):
+        self.assertEqual(music_meta.split_artists(None), [])
+        self.assertEqual(music_meta.split_artists(''), [])
+
+
+class SplitListTests(unittest.TestCase):
+    def test_ampersand_survives_user_lists(self):
+        self.assertEqual(music_meta.split_list('Hootie & the Blowfish, R&B'), ['Hootie & the Blowfish', 'R&B'])
+
+    def test_semicolons_and_whitespace(self):
+        self.assertEqual(music_meta.split_list(' a ;b, c '), ['a', 'b', 'c'])
+
+
+class SanitizePartTests(unittest.TestCase):
+    def test_strips_filesystem_specials(self):
+        self.assertEqual(music_meta.sanitize_part('AC/DC: Live? *<1980>*', 'x'), 'AC DC Live 1980')
+
+    def test_falls_back_when_empty(self):
+        self.assertEqual(music_meta.sanitize_part('...', 'Unknown Artist'), 'Unknown Artist')
+        self.assertEqual(music_meta.sanitize_part(None, 'Unknown'), 'Unknown')
+
+    def test_caps_length(self):
+        self.assertLessEqual(len(music_meta.sanitize_part('x' * 300, 'y')), 80)
+
+
+class OrganizedRelPathTests(unittest.TestCase):
+    def test_artist_album_year_layout(self):
+        rel = music_meta.organized_rel_path(['Volbeat'], 'Rewind, Replay, Rebound', '2019-08-02', 'Last Day Under the Sun', '.opus')
+        self.assertEqual(rel, os.path.join(
+            'Volbeat', 'Rewind, Replay, Rebound(2019)',
+            'Volbeat - Rewind, Replay, Rebound(2019) - Last Day Under the Sun.opus'))
+
+    def test_fallbacks(self):
+        rel = music_meta.organized_rel_path([], None, None, None, '.mp3')
+        self.assertEqual(rel, os.path.join(
+            'Unknown Artist', 'Unknown Album', 'Unknown Artist - Unknown Album - Unknown.mp3'))
+
+
+class BuildTagsTests(unittest.TestCase):
+    def test_clears_video_junk_and_sets_fields(self):
+        tags = music_meta.build_tags('Song', ['A', 'B'], 'Album', '2024', ['Rock'])
+        self.assertEqual(tags['title'], 'Song')
+        self.assertEqual(tags['artist'], ['A', 'B'])
+        self.assertEqual(tags['albumartist'], 'A')
+        self.assertEqual(tags['description'], '')
+        self.assertEqual(tags['comment'], '')
+
+
+class TagAudioFileTests(unittest.TestCase):
+    def test_tags_mp3_in_place(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, 'test.mp3')
+            # A few silent MPEG-1 Layer III frames (128 kbps, 44.1 kHz) are
+            # enough for mutagen to recognize the file as an MP3.
+            frame = b'\xff\xfb\x90\x00' + b'\x00' * 413
+            with open(path, 'wb') as f:
+                f.write(frame * 4)
+            music_meta.tag_audio_file(path, music_meta.build_tags('Song', ['Artist'], 'Album', '2024', ['Rock']))
+            from mutagen import File
+            audio = File(path, easy=True)
+            self.assertEqual(audio['title'], ['Song'])
+            self.assertEqual(audio['artist'], ['Artist'])
+            self.assertEqual(audio['album'], ['Album'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/app/tests/test_persistent_queue.py
+++ b/app/tests/test_persistent_queue.py
@@ -141,12 +141,13 @@ class PersistentQueueTests(unittest.TestCase):
                     "playlist_title": "Playlist",
                     "channel_index": "02",
                     "channel_title": "Channel",
+                    # Kept (truncated) for the music-tag dialog.
+                    "description": "very large payload",
                 },
             )
             self.assertNotIn("formats", record["entry"])
-            self.assertNotIn("description", record["entry"])
 
-    def test_completed_queue_does_not_persist_entry_or_transient_progress(self):
+    def test_completed_queue_persists_compact_entry_but_not_transient_progress(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = os.path.join(tmp, "completed")
             pq = PersistentQueue("completed", path)
@@ -159,6 +160,8 @@ class PersistentQueueTests(unittest.TestCase):
                 "playlist_index": "01",
                 "playlist_title": "Playlist",
                 "formats": [{"id": "huge"}],
+                "artist": "Forss",
+                "track": "Flickermood",
             }
             info.filename = "done.mp4"
             pq.put(_FakeDownload(info))
@@ -167,7 +170,11 @@ class PersistentQueueTests(unittest.TestCase):
                 payload = json.load(f)
 
             record = payload["items"][0]["info"]
-            self.assertNotIn("entry", record)
+            # The compact entry survives (music-tag dialog needs it after a
+            # restart); the bulky and transient fields do not.
+            self.assertEqual(record["entry"]["artist"], "Forss")
+            self.assertEqual(record["entry"]["track"], "Flickermood")
+            self.assertNotIn("formats", record["entry"])
             self.assertNotIn("percent", record)
             self.assertNotIn("speed", record)
             self.assertNotIn("eta", record)

--- a/app/tests/test_ytdl_utils.py
+++ b/app/tests/test_ytdl_utils.py
@@ -498,7 +498,7 @@ class DownloadInfoSetstateTests(unittest.TestCase):
 
 
 class CompactPersistedEntryTests(unittest.TestCase):
-    def test_keeps_only_playlist_and_channel_keys(self):
+    def test_keeps_only_restart_relevant_keys(self):
         entry = {
             "playlist_index": "01",
             "playlist_title": "Playlist",
@@ -509,7 +509,6 @@ class CompactPersistedEntryTests(unittest.TestCase):
             "n_entries": 10,
             "__last_playlist_index": 10,
             "formats": [{"id": "huge"}],
-            "description": "big blob",
         }
 
         compact = _compact_persisted_entry(entry)
@@ -527,6 +526,26 @@ class CompactPersistedEntryTests(unittest.TestCase):
                 "__last_playlist_index": 10,
             },
         )
+
+    def test_keeps_music_fields_and_truncates_description(self):
+        entry = {
+            "artist": "Forss",
+            "track": "Flickermood",
+            "album": "Soulhack",
+            "release_year": 2003,
+            "genre": "Electronic",
+            "uploader": "forss",
+            "description": "x" * 5000,
+            "formats": [{"id": "huge"}],
+        }
+
+        compact = _compact_persisted_entry(entry)
+
+        self.assertEqual(compact["artist"], "Forss")
+        self.assertEqual(compact["track"], "Flickermood")
+        self.assertEqual(compact["genre"], "Electronic")
+        self.assertEqual(len(compact["description"]), 2000)
+        self.assertNotIn("formats", compact)
 
     def test_returns_none_when_no_restart_relevant_keys_exist(self):
         self.assertIsNone(_compact_persisted_entry({"id": "x", "title": "y"}))

--- a/app/ytdl.py
+++ b/app/ytdl.py
@@ -21,6 +21,7 @@ from typing import Any, Optional
 import yt_dlp.networking.impersonate
 from yt_dlp.utils import STR_FORMAT_RE_TMPL, STR_FORMAT_TYPES
 import bg_tasks
+import music_meta
 from dl_formats import get_format, get_opts, AUDIO_FORMATS, merge_ytdl_option_layers
 from datetime import datetime
 from state_store import AtomicJsonStore, from_json_compatible, read_legacy_shelf, to_json_compatible
@@ -425,7 +426,16 @@ _PERSISTED_DOWNLOAD_FIELDS = (
 )
 
 
-_COMPACT_ENTRY_EXTRA_KEYS = frozenset(("n_entries", "__last_playlist_index"))
+# The song fields feed the music-tag dialog; keeping them in the persisted
+# entry lets finished audio downloads be tagged after a restart.
+_COMPACT_ENTRY_EXTRA_KEYS = frozenset((
+    "n_entries", "__last_playlist_index",
+    "artist", "track", "album", "release_year", "upload_date", "genre", "creator", "uploader",
+))
+
+# The source description also feeds the music-tag dialog, but can be huge;
+# persist only this much of it.
+_COMPACT_ENTRY_DESCRIPTION_MAX = 2000
 
 
 def _compact_persisted_entry(entry: Any) -> Optional[dict[str, Any]]:
@@ -436,6 +446,8 @@ def _compact_persisted_entry(entry: Any) -> Optional[dict[str, Any]]:
         for key, value in entry.items()
         if key.startswith("playlist") or key.startswith("channel") or key in _COMPACT_ENTRY_EXTRA_KEYS
     }
+    if isinstance(entry.get("description"), str) and entry["description"]:
+        compact["description"] = entry["description"][:_COMPACT_ENTRY_DESCRIPTION_MAX]
     return compact or None
 
 
@@ -814,7 +826,9 @@ class PersistentQueue:
         return sorted(items, key=lambda item: item[1].timestamp)
 
     def _should_persist_entry(self) -> bool:
-        return self.identifier != "completed"
+        # The completed queue also keeps the compact entry: its music fields
+        # and truncated description feed the music-tag dialog after a restart.
+        return True
 
     def _serialize_items(self):
         return [
@@ -1602,6 +1616,74 @@ class DownloadQueue:
         return (list((k, v.info) for k, v in self.queue.items()) +
                 list((k, v.info) for k, v in self.pending.items()),
                 list((k, v.info) for k, v in self.done.items()))
+
+    def music_source(self, id):
+        """Source material for the music-tag dialog of a finished download:
+        the video description plus whatever song metadata the site provided.
+        """
+        if not self.done.exists(id):
+            return {'status': 'error', 'msg': 'download not found'}
+        dl = self.done.get(id)
+        entry = getattr(dl.info, 'entry', None) or {}
+        return {
+            'status': 'ok',
+            'title': dl.info.title,
+            'filename': getattr(dl.info, 'filename', None),
+            'description': entry.get('description'),
+            'music': {
+                'artist': entry.get('artist') or entry.get('creator') or entry.get('uploader'),
+                'track': entry.get('track'),
+                'album': entry.get('album'),
+                'release_year': entry.get('release_year') or (str(entry.get('upload_date'))[:4] if entry.get('upload_date') else None),
+                'genre': entry.get('genre'),
+            },
+        }
+
+    async def music_tag(self, id, title, artists, album, date, genres, organize):
+        """Tag a finished audio download in place, optionally filing it into
+        an Artist/Album(Year) layout inside its download directory.
+        """
+        if not self.done.exists(id):
+            return {'status': 'error', 'msg': 'download not found'}
+        dl = self.done.get(id)
+        rel_name = getattr(dl.info, 'filename', None)
+        if dl.info.status != 'finished' or not rel_name:
+            return {'status': 'error', 'msg': 'download has no finished file to tag'}
+        ext = os.path.splitext(rel_name)[1].lower()
+        if ext not in music_meta.TAGGABLE_EXTS:
+            return {'status': 'error', 'msg': f'"{ext}" is not a taggable audio format'}
+        dldirectory, calc_error = self.__calc_download_path(dl.info.download_type, dl.info.folder)
+        if calc_error is not None or not dldirectory:
+            return {'status': 'error', 'msg': 'could not resolve download directory'}
+        real_base = os.path.realpath(dldirectory)
+        full_path = os.path.realpath(os.path.join(dldirectory, rel_name))
+        if not _is_within_directory(real_base, full_path) or not os.path.isfile(full_path):
+            return {'status': 'error', 'msg': 'file not found on disk'}
+
+        if not artists:
+            artists = ['Unknown Artist']
+        tags = music_meta.build_tags(title, artists, album, date, genres)
+        try:
+            await asyncio.to_thread(music_meta.tag_audio_file, full_path, tags)
+        except Exception as e:
+            log.warning(f'music tagging failed for {id}: {e!r}')
+            return {'status': 'error', 'msg': f'tagging failed: {e}'}
+
+        if organize:
+            new_rel = music_meta.organized_rel_path(artists, album, date, title, ext)
+            new_path = os.path.realpath(os.path.join(dldirectory, new_rel))
+            if _is_within_directory(real_base, new_path) and new_path != full_path:
+                try:
+                    os.makedirs(os.path.dirname(new_path), exist_ok=True)
+                    shutil.move(full_path, new_path)
+                    dl.info.filename = os.path.relpath(new_path, dldirectory)
+                except OSError as e:
+                    log.warning(f'organizing tagged file for {id} failed: {e!r}')
+                    return {'status': 'error', 'msg': f'tagged, but moving the file failed: {e}'}
+
+        self.done.put(dl)
+        await self.notifier.updated(dl.info)
+        return {'status': 'ok', 'filename': dl.info.filename}
 
     def close(self):
         # Kill any still-running download subprocesses (and their ffmpeg

--- a/ui/src/app/app.html
+++ b/ui/src/app/app.html
@@ -625,6 +625,104 @@
     </div>
   </form>
 
+  <!-- Music Tag Modal -->
+  <div class="modal fade" tabindex="-1" role="dialog"
+  aria-modal="true"
+  aria-labelledby="music-tag-modal-title"
+  [class.show]="musicTagModalOpen"
+  [style.display]="musicTagModalOpen ? 'block' : 'none'">
+    <div class="modal-dialog modal-lg" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 id="music-tag-modal-title" class="modal-title">Music tags</h5>
+          <button type="button" class="btn-close" aria-label="Close" (click)="closeMusicTagModal()"></button>
+        </div>
+        <div class="modal-body">
+          <div class="mb-2">
+            <strong>{{ musicTagSourceTitle }}</strong>
+            @if (musicSourceLoading) {
+              <small class="text-muted d-block">Loading source metadata…</small>
+            }
+          </div>
+          @if (musicTagDescription) {
+            <div class="mb-3">
+              <button type="button" class="btn btn-link btn-sm p-0" (click)="musicTagDescriptionExpanded = !musicTagDescriptionExpanded">
+                {{ musicTagDescriptionExpanded ? 'Hide' : 'Show' }} source description
+              </button>
+              @if (musicTagDescriptionExpanded) {
+                <pre class="border rounded p-2 mt-1" style="max-height: 160px; overflow-y: auto; white-space: pre-wrap; font-size: 0.8em;">{{ musicTagDescription }}</pre>
+              }
+            </div>
+          }
+          <div class="input-group mb-2">
+            <input type="text" class="form-control" placeholder="Search song databases (artist title)"
+              [(ngModel)]="musicSearchQuery" [ngModelOptions]="{standalone: true}" (keydown.enter)="searchMusicMeta()">
+            <button type="button" class="btn btn-primary" (click)="searchMusicMeta()" [disabled]="musicSearching">
+              {{ musicSearching ? 'Searching…' : 'Search' }}
+            </button>
+          </div>
+          @if (musicSearchMsg) {
+            <small class="text-muted">{{ musicSearchMsg }}</small>
+          }
+          @if (musicCandidates.length > 0) {
+            <div class="list-group mb-3" style="max-height: 220px; overflow-y: auto;">
+              @for (candidate of musicCandidates; track $index) {
+                <button type="button" class="list-group-item list-group-item-action d-flex align-items-center gap-2"
+                  (click)="applyMusicCandidate(candidate)">
+                  @if (candidate.cover) {
+                    <img [src]="candidate.cover" alt="" width="40" height="40" class="rounded flex-shrink-0">
+                  }
+                  <span class="text-start">
+                    <strong>{{ candidate.title }}</strong> — {{ candidate.artists.join(', ') }}<br>
+                    <small class="text-muted">
+                      {{ candidate.album }}{{ candidate.date ? ' (' + candidate.date.slice(0, 4) + ')' : '' }}
+                      {{ candidate.genres.length ? '· ' + candidate.genres.join(', ') : '' }}
+                      · {{ candidate.source }}
+                    </small>
+                  </span>
+                </button>
+              }
+            </div>
+          }
+          <div class="row g-2">
+            <div class="col-md-6">
+              <label class="form-label mb-0" for="music-tag-title"><small>Title</small></label>
+              <input id="music-tag-title" type="text" class="form-control" [(ngModel)]="musicTagTitle" [ngModelOptions]="{standalone: true}">
+            </div>
+            <div class="col-md-6">
+              <label class="form-label mb-0" for="music-tag-artists"><small>Artists (comma-separated)</small></label>
+              <input id="music-tag-artists" type="text" class="form-control" [(ngModel)]="musicTagArtists" [ngModelOptions]="{standalone: true}">
+            </div>
+            <div class="col-md-6">
+              <label class="form-label mb-0" for="music-tag-album"><small>Album</small></label>
+              <input id="music-tag-album" type="text" class="form-control" [(ngModel)]="musicTagAlbum" [ngModelOptions]="{standalone: true}">
+            </div>
+            <div class="col-md-3">
+              <label class="form-label mb-0" for="music-tag-date"><small>Date</small></label>
+              <input id="music-tag-date" type="text" class="form-control" placeholder="YYYY or YYYY-MM-DD" [(ngModel)]="musicTagDate" [ngModelOptions]="{standalone: true}">
+            </div>
+            <div class="col-md-3">
+              <label class="form-label mb-0" for="music-tag-genres"><small>Genres</small></label>
+              <input id="music-tag-genres" type="text" class="form-control" [(ngModel)]="musicTagGenres" [ngModelOptions]="{standalone: true}">
+            </div>
+          </div>
+          <div class="form-check mt-3">
+            <input type="checkbox" class="form-check-input" id="music-tag-organize" [(ngModel)]="musicTagOrganize" [ngModelOptions]="{standalone: true}">
+            <label class="form-check-label" for="music-tag-organize">
+              Move into Artist/Album folders
+            </label>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" (click)="closeMusicTagModal()">Close</button>
+          <button type="button" class="btn btn-primary" (click)="applyMusicTags()" [disabled]="musicTagApplying">
+            {{ musicTagApplying ? 'Applying…' : 'Apply tags' }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <!-- Batch Import Modal -->
   <div class="modal fade" tabindex="-1" role="dialog"
   aria-modal="true"
@@ -858,6 +956,9 @@
                 }
                 @if (entry[1].filename && canShareDownloads()) {
                   <button type="button" class="btn btn-link" [attr.aria-label]="'Share result file for ' + entry[1].title" (click)="shareDownload(entry[1])"><fa-icon [icon]="faShareNodes" /></button>
+                }
+                @if (isTaggableAudio(entry[1])) {
+                  <button type="button" class="btn btn-link" [attr.aria-label]="'Edit music tags for ' + entry[1].title" (click)="openMusicTagModal(entry[0], entry[1])"><fa-icon [icon]="faMusic" /></button>
                 }
                 <a href="{{entry[1].url}}" target="_blank" class="btn btn-link" [attr.aria-label]="'Open source URL for ' + entry[1].title"><fa-icon [icon]="faExternalLinkAlt" /></a>
                 <button type="button" class="btn btn-link" [attr.aria-label]="'Delete completed item ' + entry[1].title" (click)="delDownload('done', entry[0])"><fa-icon [icon]="faTrashAlt" /></button>

--- a/ui/src/app/app.ts
+++ b/ui/src/app/app.ts
@@ -7,7 +7,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { NgbModule, NgbTypeahead } from '@ng-bootstrap/ng-bootstrap';
 import { NgSelectModule } from '@ng-select/ng-select';
-import { faTrashAlt, faCheckCircle, faTimesCircle, faRedoAlt, faSun, faMoon, faCheck, faCircleHalfStroke, faDownload, faExternalLinkAlt, faFileImport, faFileExport, faCopy, faClock, faTachometerAlt, faSortAmountDown, faSortAmountUp, faChevronRight, faChevronDown, faUpload, faPause, faPlay, faShareNodes } from '@fortawesome/free-solid-svg-icons';
+import { faTrashAlt, faCheckCircle, faTimesCircle, faRedoAlt, faSun, faMoon, faCheck, faCircleHalfStroke, faDownload, faExternalLinkAlt, faFileImport, faFileExport, faCopy, faClock, faTachometerAlt, faSortAmountDown, faSortAmountUp, faChevronRight, faChevronDown, faUpload, faPause, faPlay, faShareNodes, faMusic } from '@fortawesome/free-solid-svg-icons';
 import { faGithub } from '@fortawesome/free-brands-svg-icons';
 import { CookieService } from 'ngx-cookie-service';
 import { AddDownloadPayload, DownloadsService } from './services/downloads.service';
@@ -32,6 +32,7 @@ import {
   CAPTION_FORMATS,
   THUMBNAIL_FORMATS,
   State,
+  MusicCandidate,
 } from './interfaces';
 import { EtaPipe, SpeedPipe, FileSizePipe } from './pipes';
 import { SelectAllCheckboxComponent, ItemCheckboxComponent, ToastContainerComponent } from './components/';
@@ -195,6 +196,7 @@ export class App implements AfterViewInit, OnInit, OnDestroy {
   faPause = faPause;
   faPlay = faPlay;
   faShareNodes = faShareNodes;
+  faMusic = faMusic;
   subtitleLanguages = [
     { id: 'en', text: 'English' },
     { id: 'ar', text: 'Arabic' },
@@ -1407,6 +1409,141 @@ export class App implements AfterViewInit, OnInit, OnDestroy {
   closeBatchImportModal(): void {
     this.batchImportModalOpen = false;
     this.lastFocusedElement?.focus();
+  }
+
+  // ---- Music tagging (finished audio downloads) ----
+  musicTagModalOpen = false;
+  musicTagId: string | null = null;
+  musicTagSourceTitle = '';
+  musicTagDescription: string | null = null;
+  musicTagDescriptionExpanded = false;
+  musicSourceLoading = false;
+  musicSearchQuery = '';
+  musicSearching = false;
+  musicCandidates: MusicCandidate[] = [];
+  musicSearchMsg = '';
+  musicTagTitle = '';
+  musicTagArtists = '';
+  musicTagAlbum = '';
+  musicTagDate = '';
+  musicTagGenres = '';
+  musicTagOrganize = false;
+  musicTagApplying = false;
+
+  isTaggableAudio(download: Download): boolean {
+    return download.status === 'finished' && !!download.filename
+      && /\.(mp3|m4a|aac|opus|ogg|oga|flac|wav)$/i.test(download.filename);
+  }
+
+  openMusicTagModal(id: string, download: Download): void {
+    this.lastFocusedElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    this.musicTagModalOpen = true;
+    this.musicTagId = id;
+    this.musicTagSourceTitle = download.title;
+    this.musicTagDescription = null;
+    this.musicTagDescriptionExpanded = false;
+    this.musicCandidates = [];
+    this.musicSearchMsg = '';
+    this.musicTagTitle = download.title;
+    this.musicTagArtists = '';
+    this.musicTagAlbum = '';
+    this.musicTagDate = '';
+    this.musicTagGenres = '';
+    this.musicSearchQuery = download.title;
+    this.musicSourceLoading = true;
+    this.downloads.musicMetaSource(id).subscribe(source => {
+      this.musicSourceLoading = false;
+      this.cdr.markForCheck();
+      if (source.status !== 'ok') {
+        return;
+      }
+      this.musicTagDescription = source.description || null;
+      const music = source.music || {};
+      // Site-provided song metadata prefills the fields; the search can
+      // overwrite them with a picked candidate.
+      if (music.track) {
+        this.musicTagTitle = music.track;
+      }
+      if (music.artist) {
+        this.musicTagArtists = music.artist;
+      }
+      if (music.album) {
+        this.musicTagAlbum = music.album;
+      }
+      if (music.release_year) {
+        this.musicTagDate = String(music.release_year);
+      }
+      if (music.genre) {
+        this.musicTagGenres = music.genre;
+      }
+      const query = [music.artist, music.track].filter(Boolean).join(' ');
+      if (query) {
+        this.musicSearchQuery = query;
+      }
+    });
+  }
+
+  closeMusicTagModal(): void {
+    this.musicTagModalOpen = false;
+    this.musicTagId = null;
+    this.lastFocusedElement?.focus();
+  }
+
+  searchMusicMeta(): void {
+    const query = this.musicSearchQuery.trim();
+    if (!query) {
+      return;
+    }
+    this.musicSearching = true;
+    this.musicSearchMsg = '';
+    this.downloads.musicMetaSearch(query).subscribe(result => {
+      this.musicSearching = false;
+      this.musicCandidates = result.candidates || [];
+      if (result.status !== 'ok') {
+        this.musicSearchMsg = 'Lookup failed — check the server connection.';
+      } else if (this.musicCandidates.length === 0) {
+        this.musicSearchMsg = 'No matches found.';
+      }
+      this.cdr.markForCheck();
+    });
+  }
+
+  applyMusicCandidate(candidate: MusicCandidate): void {
+    this.musicTagTitle = candidate.title || this.musicTagTitle;
+    this.musicTagArtists = candidate.artists.join(', ');
+    this.musicTagAlbum = candidate.album || '';
+    this.musicTagDate = candidate.date || '';
+    this.musicTagGenres = candidate.genres.join(', ');
+  }
+
+  private splitUserList(value: string): string[] {
+    return value.split(/[,;]/).map(part => part.trim()).filter(part => part.length > 0);
+  }
+
+  applyMusicTags(): void {
+    if (!this.musicTagId || !this.musicTagTitle.trim()) {
+      this.toasts.error('A song title is required.');
+      return;
+    }
+    this.musicTagApplying = true;
+    this.downloads.musicTag({
+      id: this.musicTagId,
+      title: this.musicTagTitle.trim(),
+      artists: this.splitUserList(this.musicTagArtists),
+      album: this.musicTagAlbum.trim(),
+      date: this.musicTagDate.trim() || null,
+      genres: this.splitUserList(this.musicTagGenres),
+      organize: this.musicTagOrganize,
+    }).subscribe(status => {
+      this.musicTagApplying = false;
+      if (status.status === 'ok') {
+        this.toasts.success('Music tags applied.');
+        this.closeMusicTagModal();
+      } else {
+        this.toasts.error(status.msg || 'Tagging failed.');
+      }
+      this.cdr.markForCheck();
+    });
   }
 
   // Start importing URLs from the batch modal textarea

--- a/ui/src/app/app.ts
+++ b/ui/src/app/app.ts
@@ -1429,6 +1429,9 @@ export class App implements AfterViewInit, OnInit, OnDestroy {
   musicTagGenres = '';
   musicTagOrganize = false;
   musicTagApplying = false;
+  // Discards out-of-order lookup responses: a slow earlier search must not
+  // overwrite the results of a faster later one.
+  private musicLookupToken = 0;
 
   isTaggableAudio(download: Download): boolean {
     return download.status === 'finished' && !!download.filename
@@ -1452,6 +1455,9 @@ export class App implements AfterViewInit, OnInit, OnDestroy {
     this.musicSearchQuery = download.title;
     this.musicSourceLoading = true;
     this.downloads.musicMetaSource(id).subscribe(source => {
+      if (this.musicTagId !== id) {
+        return; // the dialog was closed or reopened for another download
+      }
       this.musicSourceLoading = false;
       this.cdr.markForCheck();
       if (source.status !== 'ok') {
@@ -1486,6 +1492,7 @@ export class App implements AfterViewInit, OnInit, OnDestroy {
   closeMusicTagModal(): void {
     this.musicTagModalOpen = false;
     this.musicTagId = null;
+    this.musicLookupToken++;
     this.lastFocusedElement?.focus();
   }
 
@@ -1496,7 +1503,11 @@ export class App implements AfterViewInit, OnInit, OnDestroy {
     }
     this.musicSearching = true;
     this.musicSearchMsg = '';
+    const token = ++this.musicLookupToken;
     this.downloads.musicMetaSearch(query).subscribe(result => {
+      if (token !== this.musicLookupToken) {
+        return; // a newer search or a modal close superseded this response
+      }
       this.musicSearching = false;
       this.musicCandidates = result.candidates || [];
       if (result.status !== 'ok') {

--- a/ui/src/app/interfaces/index.ts
+++ b/ui/src/app/interfaces/index.ts
@@ -7,3 +7,4 @@ export * from './checkable';
 export * from './format';
 export * from './formats';
 export * from './subscription';
+export * from './music';

--- a/ui/src/app/interfaces/music.ts
+++ b/ui/src/app/interfaces/music.ts
@@ -1,0 +1,34 @@
+export interface MusicCandidate {
+  source: string;
+  title: string | null;
+  artists: string[];
+  album: string | null;
+  date: string | null;
+  genres: string[];
+  cover: string | null;
+}
+
+export interface MusicSource {
+  status: string;
+  msg?: string;
+  title?: string;
+  filename?: string;
+  description?: string | null;
+  music?: {
+    artist?: string | null;
+    track?: string | null;
+    album?: string | null;
+    release_year?: string | number | null;
+    genre?: string | null;
+  };
+}
+
+export interface MusicTagPayload {
+  id: string;
+  title: string;
+  artists: string[];
+  album: string;
+  date: string | null;
+  genres: string[];
+  organize: boolean;
+}

--- a/ui/src/app/services/downloads.service.ts
+++ b/ui/src/app/services/downloads.service.ts
@@ -3,7 +3,7 @@ import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { of, Subject } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 import { MeTubeSocket } from './metube-socket.service';
-import { Download, Status, State } from '../interfaces';
+import { Download, Status, State, MusicCandidate, MusicSource, MusicTagPayload } from '../interfaces';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 export interface AddDownloadPayload {
@@ -159,6 +159,24 @@ export class DownloadsService {
     if (cs) body['clip_start'] = cs;
     if (ce) body['clip_end'] = ce;
     return this.http.post<Status>('add', body).pipe(
+      catchError(this.handleHTTPError)
+    );
+  }
+
+  public musicMetaSearch(q: string) {
+    return this.http.get<{ status: string; candidates: MusicCandidate[] }>('music-meta', { params: { q } }).pipe(
+      catchError((err: HttpErrorResponse) => of({ status: 'error', candidates: [] as MusicCandidate[], msg: err.error?.msg || err.message }))
+    );
+  }
+
+  public musicMetaSource(id: string) {
+    return this.http.get<MusicSource>('music-meta/source', { params: { id } }).pipe(
+      catchError((err: HttpErrorResponse) => of({ status: 'error', msg: err.error?.msg || err.message } as MusicSource))
+    );
+  }
+
+  public musicTag(payload: MusicTagPayload) {
+    return this.http.post<Status>('music-tag', payload).pipe(
       catchError(this.handleHTTPError)
     );
   }


### PR DESCRIPTION
Implements #1026.

## What

Finished audio downloads get a music-note action that opens a **Music tags** dialog:

- Shows the **source description** (collapsible) and pre-fills the tag fields from the site-provided song metadata (`artist`/`track`/`album`/`release_year`/`genre`).
- **Search** queries iTunes Search + Deezer (keyless, in parallel, 8 s timeout, only on user action) and lists up to 10 deduplicated candidates with cover art; clicking one fills the fields.
- **Apply tags** rewrites the file in place with mutagen (existing dependency) — multi-value artist/genre tags, `albumartist`, and clearing of the video-site leftovers (`description`/`comment`/`purl`) that `--embed-metadata` writes.
- Optional **Move into Artist/Album folders**: files the track as `Artist/Album(Year)/Artist - Album(Year) - Title.ext` inside its download directory (path-safety checked with the existing `_is_within_directory`), updating `info.filename` so the result link keeps working.

## How

- `app/music_meta.py` (new): provider lookups, artist/list splitting, filesystem-safe path parts, mutagen tagging.
- `app/main.py`: `GET music-meta` (search), `GET music-meta/source` (description + site metadata of a done download), `POST music-tag` (apply).
- `app/ytdl.py`: `DownloadQueue.music_source()` / `music_tag()`; the completed queue now persists the compact entry (music fields + description truncated to 2 kB, < 3 kB per item) so tagging still has its source data after a restart.
- UI: dialog + row action in `app.ts`/`app.html`, service methods, `MusicCandidate`/`MusicSource` interfaces. Subscribe callbacks call `cdr.markForCheck()` per the app's OnPush convention.

## Tests

- `app/tests/test_music_meta.py` (new): splitting, sanitizing, layout, tag building, real mutagen retag of a generated MP3.
- Updated the two persistence tests for the compact-entry change.
- All suites pass: 270 backend tests, 40 frontend tests, lint clean, README stays under the 25 k Docker Hub limit (24.5 k).

## Verified end-to-end

Built the Docker image and drove the real flow with Playwright against a SoundCloud track: download as mp3 → dialog shows description + site metadata → iTunes/Deezer candidates render → apply with organize → mutagen tags verified on disk, file at `Forss/Belle et Fou (Original Soundtrack)(2007)/… - Flickermood.mp3`, result link still valid, and source data still present after a container restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)