### PR TITLE
fix: release per-download status_queue proxy on close to stop file-descriptor leak

### DIFF
--- a/app/tests/test_download_queue.py
+++ b/app/tests/test_download_queue.py
@@ -898,6 +898,40 @@ def _make_download(dq_env, *, download_type="video", status="downloading", filen
     )
 
 
+def test_download_close_releases_status_queue(dq_env):
+    download = _make_download(dq_env)
+    status_queue = MagicMock()
+    proc = MagicMock()
+    download.status_queue = status_queue
+    download.proc = proc
+
+    download.close()
+
+    proc.close.assert_called_once()
+    assert download.status_queue is None
+
+
+def test_download_close_releases_status_queue_without_process(dq_env):
+    download = _make_download(dq_env)
+    download.status_queue = MagicMock()
+
+    download.close()
+
+    assert download.status_queue is None
+
+
+def test_download_close_releases_status_queue_when_process_close_fails(dq_env):
+    download = _make_download(dq_env)
+    download.status_queue = MagicMock()
+    download.proc = MagicMock()
+    download.proc.close.side_effect = RuntimeError('close failed')
+
+    with pytest.raises(RuntimeError, match='close failed'):
+        download.close()
+
+    assert download.status_queue is None
+
+
 @pytest.mark.asyncio
 async def test_post_download_cleanup_clears_filename_on_error(dq_env):
     notifier = AsyncMock()

--- a/app/ytdl.py
+++ b/app/ytdl.py
@@ -758,8 +758,11 @@ class Download:
 
     def close(self):
         log.info(f"Closing download process for: {self.info.title}")
-        if self.started():
-            self.proc.close()
+        try:
+            if self.started():
+                self.proc.close()
+        finally:
+            self.status_queue = None
 
     def running(self):
         try:


### PR DESCRIPTION
## Summary

Downloading a very long playlist eventually crashes MeTube with `OSError: [Errno 24] Too many open files`, and the process self-terminates. This releases the per-download `status_queue` manager proxy when a download finishes, so its socket file descriptor is torn down instead of leaking one per completed item.

## Background

andbir reported this in #485, and two commenters independently reproduced the FD exhaustion — one on kernel 6.6.44, which rules out the "old Linux kernel" theory and points at a real leak in MeTube. Each `Download` creates its own `multiprocessing.Manager().Queue()` proxy (`self.status_queue`), and every completed download stays live in the in-memory `PersistentQueue.dict` (`self.done`). Those retained objects keep their Queue proxy, whose client connection to the manager holds a socket FD open. `Download.close()` closed only `self.proc` and never dropped `self.status_queue`, so FDs accumulate across a long playlist until the limit is hit.

`close()` now clears `self.status_queue` in a `finally` block (so the reference is dropped even if `self.proc.close()` raises, and when no process was ever started), letting the proxy be garbage-collected — `Connection.__del__` then closes the FD. This is safe because `close()` runs only after `start()` has awaited `self.status_task`, so no reader remains, and a re-started download reassigns a fresh queue. Added tests for the normal, no-process, and failing-`proc.close()` paths; `pytest app/tests/test_download_queue.py` passes (34 tests).

Closes #485
