### PR TITLE
feat: accept a pasted share blurb by extracting the URL from it

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -448,6 +448,31 @@ def _clip_field_provided_in_post(raw) -> bool:
     return True
 
 
+# A URL copied out of a share blurb is ASCII; stopping at the first byte outside
+# printable ASCII ends the match at the surrounding prose without naming any
+# particular script or platform.
+_SHARE_TEXT_URL_RE = re.compile(r'https?://[\x21-\x7e]+')
+_URL_TRAILING_PUNCTUATION = '.,;:!?\'")]}>'
+
+
+def _extract_url_from_share_text(value: str) -> str:
+    """Return the URL embedded in a share blurb pasted in place of a bare URL.
+
+    Mobile apps hand out a sentence rather than a link -- Douyin's share text
+    wraps ``https://v.douyin.com/...`` in a share code, a caption and hashtags --
+    and pasting the whole string fails with an empty URL scheme, which reads as a
+    MeTube bug rather than a malformed paste. A value that already starts with a
+    scheme is returned untouched, and text with no URL in it is left alone for the
+    existing validation to reject.
+    """
+    if value.lower().startswith(('http://', 'https://')):
+        return value
+    match = _SHARE_TEXT_URL_RE.search(value)
+    if not match:
+        return value
+    return match.group(0).rstrip(_URL_TRAILING_PUNCTUATION)
+
+
 def _extract_t_query_from_url(url: str) -> tuple[str, float | None]:
     """If ``t=`` is present and parseable, return URL without ``t`` and start seconds.
 
@@ -719,7 +744,7 @@ def parse_download_options(post: dict) -> dict:
     quality = post.get('quality')
     if not url or not quality or not download_type:
         raise web.HTTPBadRequest(reason="missing 'url', 'download_type', or 'quality'")
-    url = str(url).strip()
+    url = _extract_url_from_share_text(str(url).strip())
     folder = post.get('folder')
     custom_name_prefix = post.get('custom_name_prefix')
     playlist_item_limit = post.get('playlist_item_limit')

--- a/app/tests/test_main_helpers.py
+++ b/app/tests/test_main_helpers.py
@@ -299,6 +299,56 @@ class ParseDownloadOptionsTests(unittest.TestCase):
             })
 
 
+class ExtractUrlFromShareTextTests(unittest.TestCase):
+    # A real Douyin share blurb: share code, caption, hashtags, then the link,
+    # then a trailing instruction sentence.
+    SHARE_TEXT = (
+        "2.82 V@l.Cu 09/15 uFu:/ :0pm \u7b49\u4e8640\u5e74 # \u6297\u764c "
+        "https://v.douyin.com/J0v9moTyERw/ \u590d\u5236\u6b64\u94fe\u63a5\uff0c"
+        "\u6253\u5f00Dou\u97f3\u641c\u7d22\uff0c\u76f4\u63a5\u89c2\u770b\u89c6\u9891\uff01"
+    )
+
+    def test_pulls_url_out_of_share_text(self):
+        self.assertEqual(
+            main._extract_url_from_share_text(self.SHARE_TEXT),
+            "https://v.douyin.com/J0v9moTyERw/",
+        )
+
+    def test_plain_url_is_untouched(self):
+        url = "https://www.youtube.com/watch?v=1&t=855s"
+        self.assertEqual(main._extract_url_from_share_text(url), url)
+
+    def test_text_without_url_is_left_for_validation(self):
+        text = "no link here at all"
+        self.assertEqual(main._extract_url_from_share_text(text), text)
+
+    def test_stops_before_adjacent_non_ascii_punctuation(self):
+        # The URL is followed immediately by a full-width comma, which must not
+        # become part of the URL.
+        text = "\u770b\u770b\u8fd9\u4e2a https://v.douyin.com/abc123/\uff0c\u5f88\u597d\u7b11"
+        self.assertEqual(
+            main._extract_url_from_share_text(text),
+            "https://v.douyin.com/abc123/",
+        )
+
+    def test_strips_trailing_sentence_punctuation(self):
+        text = "see https://example.com/watch?v=1."
+        self.assertEqual(
+            main._extract_url_from_share_text(text),
+            "https://example.com/watch?v=1",
+        )
+
+    def test_parse_download_options_accepts_share_text(self):
+        parsed = main.parse_download_options({
+            "url": self.SHARE_TEXT,
+            "download_type": "video",
+            "codec": "auto",
+            "format": "any",
+            "quality": "best",
+        })
+        self.assertEqual(parsed["url"], "https://v.douyin.com/J0v9moTyERw/")
+
+
 class GetCustomDirsTests(unittest.TestCase):
     def test_works_without_a_running_event_loop(self):
         # get_custom_dirs() used to time its cache via


### PR DESCRIPTION
## The problem

Douyin — the Chinese version of TikTok, a different app from the international
one — does not give you a URL when you share a video. Tapping **分享 → 复制链接**
("Share → Copy link") puts this on the clipboard:

```
2.82 V@l.Cu 09/15 uFu:/ :0pm 等了40年，癌症疫苗真的成了！ # 癌症疫苗 # 创新药  https://v.douyin.com/J0v9moTyERw/ 复制此链接，打开Dou音搜索，直接观看视频！
```

That is not a user mangling a paste. **That string is the app's copy-link output**,
and it is what every Douyin user has in their clipboard: a numeric share code, an
obfuscated token, the caption, hashtags, the actual URL, and a trailing instruction
sentence. The mobile app offers no "copy plain URL" option — the blurb is the only
thing the share button produces.

Pasted into MeTube it fails:

```
Error adding URL: URL scheme "" is not allowed (only http and https)
```

The URL is sitting in plain view in the middle of the string the app just generated,
so the refusal reads as a MeTube bug. The workaround is to hand-edit the clipboard
before every single paste.

WeChat and Xiaohongshu wrap shared links the same way, so this is the normal shape of
a shared link across the Chinese app ecosystem rather than one platform's quirk.

## Why this belongs in MeTube

yt-dlp already has a Douyin extractor, and these downloads work perfectly once the URL
is clean — I have Douyin videos downloaded through MeTube right now. So MeTube already
holds up its side of "give it a URL, it runs yt-dlp well". The *only* thing standing
between a Douyin user and a working download is that the clipboard contains a sentence
instead of a bare URL.

## The change

`parse_download_options` runs the incoming value through a new
`_extract_url_from_share_text` before validation:

- A value that already starts with `http://` or `https://` is returned untouched, so
  no existing caller changes behaviour.
- Otherwise the first `https?://` run is extracted. The character class stops at the
  first byte outside printable ASCII, so the surrounding prose ends the match without
  the code knowing anything about Chinese or any other script.
- Trailing sentence punctuation is trimmed.
- Text containing no URL is passed through unchanged and still hits the existing
  validation error.

There is deliberately no site-specific knowledge here: no host list, no share-code
parsing, nothing that breaks when Douyin changes its blurb format. It is input
normalisation of the same kind as the existing `_extract_t_query_from_url`, and it
adds no config surface.

## Tests

Six cases in `app/tests/test_main_helpers.py`, including the real Douyin blurb above
and the case where a full-width comma immediately follows the URL (it must not be
swallowed into the URL).

`app/tests/test_main_helpers.py` — 37 passed.

I also see 35 failures in `app/tests/test_subscriptions.py` locally, but they are
identical with and without this patch (verified by stashing it) on both Python 3.13
and 3.14, and at least some are artifacts of my own network setup. Flagging them only
so the number isn't a surprise; they look unrelated to this change.
